### PR TITLE
Add max framerate feature + FPS class

### DIFF
--- a/gst-plugin/src/drpai.cpp
+++ b/gst-plugin/src/drpai.cpp
@@ -516,6 +516,11 @@ int8_t DRPAI::print_result_yolo()
 }
 
 int DRPAI::open_resources() {
+    if (drpai_rate.max_rate == 0) {
+        printf("[WARNING] DRPAI is disabled by the zero max framerate.\n");
+        return 0;
+    }
+
     printf("RZ/V2L DRP-AI Plugin\n");
     printf("Model : Darknet YOLO      | %s\n", drpai_prefix.c_str());
 
@@ -607,7 +612,7 @@ int DRPAI::open_resources() {
 }
 
 int DRPAI::process_image(uint8_t* img_data) {
-    if (thread_state != Processing) {
+    if (drpai_rate.max_rate != 0 && thread_state != Processing) {
         switch (thread_state) {
             case Failed:
             case Unknown:
@@ -627,7 +632,7 @@ int DRPAI::process_image(uint8_t* img_data) {
         }
     }
 
-    if(!multithread)
+    if(drpai_rate.max_rate != 0 && !multithread)
         if (thread_function_single() != 0)
             return -1;
 

--- a/gst-plugin/src/drpai.cpp
+++ b/gst-plugin/src/drpai.cpp
@@ -5,8 +5,6 @@
 #include <memory>
 #include "drpai.h"
 
-#define NOW std::chrono::steady_clock::now()
-
 /*****************************************
 * Function Name : read_addrmap_txt
 * Description   : Loads address and size of DRP-AI Object files into struct addr.
@@ -521,7 +519,6 @@ int DRPAI::open_resources() {
     printf("RZ/V2L DRP-AI Plugin\n");
     printf("Model : Darknet YOLO      | %s\n", drpai_prefix.c_str());
 
-    frame_time = NOW;
     if (multithread)
         process_thread = new std::thread(&DRPAI::thread_function_loop, this);
     else
@@ -610,24 +607,23 @@ int DRPAI::open_resources() {
 }
 
 int DRPAI::process_image(uint8_t* img_data) {
-    {
+    if (thread_state != Processing) {
         switch (thread_state) {
             case Failed:
             case Unknown:
             case Closing:
                 return -1;
-            case Processing:
-                break;
 
             case Ready:
                 if(image_mapped_udma.img_buffer)
                     std::memcpy(image_mapped_udma.img_buffer, img_data, image_mapped_udma.get_size());
                 //std::this_thread::sleep_for(std::chrono::milliseconds(50));
-                if(show_fps)
-                    drpai_frame_count++;
                 thread_state = Processing;
                 if (multithread)
                     v.notify_one();
+
+            default:
+                break;
         }
     }
 
@@ -637,20 +633,11 @@ int DRPAI::process_image(uint8_t* img_data) {
 
     Image img (DRPAI_IN_WIDTH, DRPAI_IN_HEIGHT, DRPAI_IN_CHANNEL_BGR);
     img.img_buffer = img_data;
-
+    video_rate.inform_frame();
     if(show_fps) {
-        video_frame_count++;
-        if (std::chrono::duration<double>(NOW - frame_time).count() >= 1) {
-            frame_time = NOW;
-            video_rate = video_frame_count;
-            drpai_rate = drpai_frame_count;
-            video_frame_count = 0;
-            drpai_frame_count = 0;
-        }
-
-        auto rate_str = "Video Rate: " + std::to_string(int(video_rate)) + " fps";
+        auto rate_str = "Video Rate: " + std::to_string(int(video_rate.get_smooth_rate())) + " fps";
         img.write_string(rate_str, 0, 0, WHITE_DATA, BLACK_DATA, 5);
-        rate_str = "DRPAI Rate: " + (drpai_fd ? std::to_string(int(drpai_rate)) + " fps" : "N/A");
+        rate_str = "DRPAI Rate: " + (drpai_fd ? std::to_string(int(drpai_rate.get_smooth_rate())) + " fps" : "N/A");
         img.write_string(rate_str, 0, 15, WHITE_DATA, BLACK_DATA, 5);
     }
 
@@ -710,7 +697,7 @@ int8_t DRPAI::thread_function_single() {
         }
     }
 
-    //std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    drpai_rate.inform_frame();
 
     if(drpai_fd) {
         /**********************************************************************

--- a/gst-plugin/src/drpai.h
+++ b/gst-plugin/src/drpai.h
@@ -11,13 +11,13 @@
 #include "define.h"
 #include "box.h"
 #include "image.h"
+#include "fps.h"
 #include <string>
 #include <vector>
 #include <array>
 #include <thread>
 #include <mutex>
 #include <condition_variable>
-#include <chrono>
 
 class DRPAI {
 
@@ -28,6 +28,8 @@ public:
     bool multithread = true;
     bool log_detects = false;
     bool show_fps = false;
+    fps video_rate{};
+    fps drpai_rate{};
     int open_resources();
     int process_image(uint8_t* img_data);
     int release_resources();
@@ -49,11 +51,6 @@ private:
     std::vector<detection> last_det{};
     int8_t get_result(uint32_t output_addr, uint32_t output_size);
     int8_t print_result_yolo();
-
-    /* FPS Section */
-    std::chrono::time_point<std::chrono::steady_clock> frame_time;
-    int8_t video_frame_count = 0, drpai_frame_count = 0;
-    double video_rate=0, drpai_rate=0;
 
     /* Thread Section */
     enum ThreadState { Unknown, Ready, Processing, Failed, Closing };

--- a/gst-plugin/src/fps.h
+++ b/gst-plugin/src/fps.h
@@ -25,10 +25,12 @@ public:
             frame_durations.pop_back();
         last_time = now;
 
-        auto s = int32_t(1000.f/max_rate) - int32_t(duration);
-        if (s > 0)
+        auto s = int32_t(1000.f/max_rate) - int32_t(duration) + last_sleep_duration;
+        if (s > 0) {
+            last_sleep_duration = s;
             //for some reason I had to add 25 milliseconds to this sleep to match the max_rate result. I don't know why.
-            std::this_thread::sleep_for(std::chrono::milliseconds(s+25));
+            std::this_thread::sleep_for(std::chrono::milliseconds(s + 25));
+        }
     }
 
     [[nodiscard]] float get_smooth_durations() const {
@@ -39,6 +41,7 @@ public:
     [[nodiscard]] float get_smooth_rate() const { return 1000.0f / get_smooth_durations(); }
 
 private:
+    int32_t last_sleep_duration = 0;
     std::chrono::time_point<std::chrono::steady_clock> last_time;
     std::list<uint32_t> frame_durations;
 };

--- a/gst-plugin/src/fps.h
+++ b/gst-plugin/src/fps.h
@@ -1,0 +1,46 @@
+//
+// Created by matin on 03/03/23.
+//
+
+#ifndef GSTREAMER1_0_DRPAI_FPS_H
+#define GSTREAMER1_0_DRPAI_FPS_H
+
+#include <chrono>
+#include <list>
+#include <numeric>
+#include <thread>
+
+class fps {
+public:
+    float max_rate = 120;
+    uint32_t smooth_rate = 1;
+
+    explicit fps(): last_time(std::chrono::steady_clock::now()) {}
+
+    void inform_frame() {
+        auto now = std::chrono::steady_clock::now();
+        uint32_t duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_time).count();
+        frame_durations.push_front(duration);
+        if (frame_durations.size() > smooth_rate)
+            frame_durations.pop_back();
+        last_time = now;
+
+        auto s = int32_t(1000.f/max_rate) - int32_t(duration);
+        if (s > 0)
+            //for some reason I had to add 25 milliseconds to this sleep to match the max_rate result. I don't know why.
+            std::this_thread::sleep_for(std::chrono::milliseconds(s+25));
+    }
+
+    [[nodiscard]] float get_smooth_durations() const {
+        return (float)std::accumulate(frame_durations.begin(), frame_durations.end(), 0.0)
+                / (float)frame_durations.size();
+    }
+    [[nodiscard]] float get_last_rate() const { return 1000.0f / float(frame_durations.front()); }
+    [[nodiscard]] float get_smooth_rate() const { return 1000.0f / get_smooth_durations(); }
+
+private:
+    std::chrono::time_point<std::chrono::steady_clock> last_time;
+    std::list<uint32_t> frame_durations;
+};
+
+#endif //GSTREAMER1_0_DRPAI_FPS_H

--- a/gst-plugin/src/gstdrpai.cpp
+++ b/gst-plugin/src/gstdrpai.cpp
@@ -148,8 +148,8 @@ gst_drpai_class_init(GstDRPAIClass *klass) {
                            0.001f, 120.f, 120.f, G_PARAM_READWRITE));
     g_object_class_install_property(gobject_class, PROP_MAX_DRPAI_RATE,
         g_param_spec_float("max_drpai_rate", "Max DRPAI Framerate",
-                           "Intentionally add thread sleeps to control the maximum DRPAI framerate.",
-                            0.001f, 120.f, 120.f, G_PARAM_READWRITE));
+                           "Intentionally add thread sleeps to control the maximum DRPAI framerate. Zero means disabled.",
+                            0.0f, 120.f, 120.f, G_PARAM_READWRITE));
     g_object_class_install_property(gobject_class, PROP_SMOOTH_VIDEO_RATE,
         g_param_spec_uint("smooth_video_rate", "Smooth Video Framerate",
                              "Averages the last number of video framerates to show a more smooth number.",

--- a/gst-plugin/src/gstdrpai.cpp
+++ b/gst-plugin/src/gstdrpai.cpp
@@ -79,6 +79,11 @@ enum {
     PROP_SHOW_FPS,
     PROP_LOG_DETECTS,
     PROP_STOP_ERROR,
+
+    PROP_MAX_VIDEO_RATE,
+    PROP_MAX_DRPAI_RATE,
+    PROP_SMOOTH_VIDEO_RATE,
+    PROP_SMOOTH_DRPAI_RATE,
 };
 
 /* the capabilities of the inputs and outputs.
@@ -122,17 +127,37 @@ gst_drpai_class_init(GstDRPAIClass *klass) {
     gstelement_class->change_state = gst_drpai_change_state;
 
     g_object_class_install_property(gobject_class, PROP_MULTITHREAD,
-                                    g_param_spec_boolean("multithread", "MultiThread", "Use a separate thread for object detection.",
-                                                         TRUE, G_PARAM_READWRITE));
+        g_param_spec_boolean("multithread", "MultiThread",
+                             "Use a separate thread for object detection.",
+                             TRUE, G_PARAM_READWRITE));
     g_object_class_install_property(gobject_class, PROP_LOG_DETECTS,
-                                    g_param_spec_boolean("log_detects", "Log Detects", "Print detected objects in standard output.",
-                                                         FALSE, G_PARAM_READWRITE));
+        g_param_spec_boolean("log_detects", "Log Detects",
+                             "Print detected objects in standard output.",
+                             FALSE, G_PARAM_READWRITE));
     g_object_class_install_property(gobject_class, PROP_SHOW_FPS,
-                                    g_param_spec_boolean("show_fps", "Show Frame Rates", "Render video and object detection frame rates at the corner of the video.",
-                                                         FALSE, G_PARAM_READWRITE));
+        g_param_spec_boolean("show_fps", "Show Frame Rates",
+                             "Render video and object detection frame rates at the corner of the video.",
+                             FALSE, G_PARAM_READWRITE));
     g_object_class_install_property(gobject_class, PROP_STOP_ERROR,
-                                    g_param_spec_boolean("stop_error", "Stop On Errors", "Stop the gstreamer if kernel modules fail to open.",
-                                                         TRUE, G_PARAM_READWRITE));
+        g_param_spec_boolean("stop_error", "Stop On Errors",
+                             "Stop the gstreamer if kernel modules fail to open.",
+                             TRUE, G_PARAM_READWRITE));
+    g_object_class_install_property(gobject_class, PROP_MAX_VIDEO_RATE,
+        g_param_spec_float("max_video_rate", "Max Video Framerate",
+                           "Intentionally add thread sleeps to control the maximum video framerate.",
+                           0.001f, 120.f, 120.f, G_PARAM_READWRITE));
+    g_object_class_install_property(gobject_class, PROP_MAX_DRPAI_RATE,
+        g_param_spec_float("max_drpai_rate", "Max DRPAI Framerate",
+                           "Intentionally add thread sleeps to control the maximum DRPAI framerate.",
+                            0.001f, 120.f, 120.f, G_PARAM_READWRITE));
+    g_object_class_install_property(gobject_class, PROP_SMOOTH_VIDEO_RATE,
+        g_param_spec_uint("smooth_video_rate", "Smooth Video Framerate",
+                             "Averages the last number of video framerates to show a more smooth number.",
+                             0, 1000, 1, G_PARAM_READWRITE));
+    g_object_class_install_property(gobject_class, PROP_SMOOTH_DRPAI_RATE,
+        g_param_spec_uint("smooth_drpai_rate", "Smooth DRPAI Framerate",
+                             "Averages the last number of DRPAI framerates to show a more smooth number.",
+                             0, 1000, 1, G_PARAM_READWRITE));
 
     gst_element_class_set_details_simple(gstelement_class,
                                          "DRP-AI",
@@ -220,6 +245,18 @@ gst_drpai_set_property(GObject *object, guint prop_id,
         case PROP_STOP_ERROR:
             obj->stop_error = g_value_get_boolean(value);
             break;
+        case PROP_MAX_VIDEO_RATE:
+            obj->drpai->video_rate.max_rate = g_value_get_float(value);
+            break;
+        case PROP_MAX_DRPAI_RATE:
+            obj->drpai->drpai_rate.max_rate = g_value_get_float(value);
+            break;
+        case PROP_SMOOTH_VIDEO_RATE:
+            obj->drpai->video_rate.smooth_rate = g_value_get_uint(value);
+            break;
+        case PROP_SMOOTH_DRPAI_RATE:
+            obj->drpai->drpai_rate.smooth_rate = g_value_get_uint(value);
+            break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
             break;
@@ -243,6 +280,18 @@ gst_drpai_get_property(GObject *object, guint prop_id,
             break;
         case PROP_STOP_ERROR:
             g_value_set_boolean(value, obj->stop_error);
+            break;
+        case PROP_MAX_VIDEO_RATE:
+            g_value_set_float(value, obj->drpai->video_rate.max_rate);
+            break;
+        case PROP_MAX_DRPAI_RATE:
+            g_value_set_float(value, obj->drpai->drpai_rate.max_rate);
+            break;
+        case PROP_SMOOTH_VIDEO_RATE:
+            g_value_set_uint(value, obj->drpai->video_rate.smooth_rate);
+            break;
+        case PROP_SMOOTH_DRPAI_RATE:
+            g_value_set_uint(value, obj->drpai->drpai_rate.smooth_rate);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);

--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,9 @@ project('gst-drpai', 'c', 'cpp', version : '1.19.0.1', license : 'LGPL')
 
 plugins_install_dir = join_paths('/usr/lib64', 'gstreamer-1.0')
 
+if get_option('buildtype') == 'release'
+  add_project_arguments('-Ofast', language : 'cpp')
+endif
 cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')
 


### PR DESCRIPTION
In this pull request, I use the `fps` class to manage max framerate properties.

Inside the `fps` class, I call the sleep function (inside the video or DRPAI threads) to bring the framerate down to the desired number.