### PR TITLE
Re-implement tracker based by sorting distances and mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,11 @@ jobs:
     - name: setup meson
       run: meson setup build
       
-    - name: make
-      run: ninja -C build
+    - name: compile
+      run: meson compile -C build
+
+    - name: test
+      run: meson test -C build
       
     - name: gst-inspect
       run: gst-inspect-1.0 build/gst-plugin/libgstdrpai.so

--- a/gst-plugin/meson.build
+++ b/gst-plugin/meson.build
@@ -29,4 +29,5 @@ gstplugindrpai = library('gstdrpai',
   install_dir : join_paths('/usr/lib64', 'gstreamer-1.0'),
 )
 
+subdir('tests')
 subdir('src/dynamic-post-process/yolo')

--- a/gst-plugin/src/box.cpp
+++ b/gst-plugin/src/box.cpp
@@ -94,11 +94,7 @@ float Box::iou_with(const Box& b) const
 
 float Box::doa_with(const Box& b) const
 {
-    const float my_center_x = x+w/2;
-    const float my_center_y = y+h/2;
-    const float b_center_x = b.x+b.w/2;
-    const float b_center_y = b.y+b.h/2;
-    const double distance = std::pow(my_center_x-b_center_x, 2) + std::pow(my_center_y-b_center_y, 2);
+    const double distance = std::pow(x-b.x, 2) + std::pow(y-b.y, 2);
     const double avg_area = (area() + b.area()) / 2.0;
     return static_cast<float>(distance/avg_area);
 }

--- a/gst-plugin/src/drpai-models/drpai_yolo.cpp
+++ b/gst-plugin/src/drpai-models/drpai_yolo.cpp
@@ -53,7 +53,6 @@ void DRPAI_Yolo::extract_detections()
     filter_boxes_nms(det, det_size, TH_NMS);
 
     last_det.clear();
-    last_tracked_detection.clear();
     for (uint8_t i = 0; i<det_size; i++) {
         /* Skip the overlapped bounding boxes */
         if (det[i].prob == 0) continue;
@@ -62,20 +61,18 @@ void DRPAI_Yolo::extract_detections()
         if (!filter_classes.empty() && in(det[i].name, filter_classes)) continue;
         if ((filter_region & det[i].bbox) == 0) continue;
 
-        if (det_tracker.active)
-            last_tracked_detection.push_back(det_tracker.track(det[i]));
-        else
-            last_det.push_back(det[i]);
+        last_det.push_back(det[i]);
     }
+    last_tracked_detection = det_tracker.track(last_det);
 
     /* Print details */
     if(log_detects) {
         if (det_tracker.active) {
             std::cout << "DRP-AI tracked items:  ";
-            for (const auto &detection: last_tracked_detection) {
+            for (const auto detection: last_tracked_detection) {
                 /* Print the box details on console */
                 //print_box(detection, n++);
-                std::cout << detection.to_string_hr() + "\t";
+                std::cout << detection->to_string_hr() + "\t";
             }
         }
         else {
@@ -102,7 +99,7 @@ void DRPAI_Yolo::render_detections_on_image(Image &img) {
         for (const auto& tracked: last_tracked_detection)
         {
             /* Draw the bounding box on the image */
-            img.draw_rect(tracked.last_detection.bbox, tracked.to_string_hr());
+            img.draw_rect(tracked->last_detection.bbox, tracked->to_string_hr());
         }
     else
         DRPAI_Connection::render_detections_on_image(img);

--- a/gst-plugin/src/drpai-models/drpai_yolo.h
+++ b/gst-plugin/src/drpai-models/drpai_yolo.h
@@ -30,7 +30,7 @@ public:
 
 private:
     uint32_t detection_buffer_size = 10;
-    std::vector<tracked_detection> last_tracked_detection {};
+    std::vector<tracked_detection*> last_tracked_detection {};
 };
 
 

--- a/gst-plugin/src/drpai-models/drpai_yolo.h
+++ b/gst-plugin/src/drpai-models/drpai_yolo.h
@@ -30,7 +30,7 @@ public:
 
 private:
     uint32_t detection_buffer_size = 10;
-    std::vector<tracked_detection*> last_tracked_detection {};
+    std::vector<const tracked_detection*> last_tracked_detection {};
 };
 
 

--- a/gst-plugin/src/tracker.cpp
+++ b/gst-plugin/src/tracker.cpp
@@ -4,6 +4,13 @@
 
 #include <algorithm>
 #include "tracker.h"
+#define std_erase(vector, pred)     vector.erase(std::remove_if(vector.begin(), vector.end(), pred), vector.end())
+#define std_sort(vector, pred)      std::sort(vector.begin(), vector.end(), pred)
+#define std_count_if(vector, pred)  std::count_if(vector.begin(), vector.end(), pred)
+
+inline double get_duration(const tracking_time &a, const tracking_time &b) {
+    return std::chrono::duration<double>(a - b).count();
+}
 
 std::string to_string(const tracking_time& time) {
     const std::time_t t = std::chrono::system_clock::to_time_t(time);
@@ -12,63 +19,84 @@ std::string to_string(const tracking_time& time) {
     return ts;
 }
 
-struct track_map {
-    const detection* det;
-    tracked_detection* t;
-    float distance;
-};
-
+/** @brief Track detected items based on previous detections
+ *  @param detections A list of detected items in one frame
+ *  @returns A list of items corresponding to detections that were present earlier.
+ *           The order of items in the output list is not the same as the input list. */
 std::vector<const tracked_detection*> tracker::track(const std::vector<detection>& detections) {
     const auto now = std::chrono::system_clock::now();
+
+    /* Let's keep pointers to all detected items.
+     * It helps with matching and crossing something that has already been checked. */
     std::vector<const detection*> detections_ptr;
     detections_ptr.reserve(detections.size());
     for(const auto& d: detections)
         detections_ptr.push_back(&d);
 
-    std::vector<track_map> m;
-    for(auto& det_item: detections_ptr) {
-        for(auto track_item = current_items.begin(); track_item != current_items.end();) {
-            if(std::chrono::duration<double>(now - track_item->seen_last).count() < time_threshold) {
-                if(track_item->last_detection.c == det_item->c) {
+    /* Create a permutation of "newly detected items" and "previously tracked items" and calculate the distance of each.
+     * Then, we sort the distances. The least distance should be the one that matches correctly. */
+    struct track_map {
+        const detection* det;
+        tracked_detection* t;
+        float distance;
+    };
+    std::vector<track_map> permutation;
+
+    for(auto track_item = current_items.begin(); track_item != current_items.end();) {
+
+        // Check to see if previously tracked item has not been seen during the past time_threshold time
+        if(get_duration(now, track_item->seen_last) < time_threshold) {
+            for(auto& det_item: detections_ptr) {
+
+                // Check if both items in previously tracked and newly detected are in the same class
+                if (track_item->last_detection.c == det_item->c) {
+                    /* Check if both items in previously tracked and newly detected are located nearby.
+                     *This is calculated using the DOA (Distance Over Areas) algorithm. */
                     if (const auto distance = track_item->last_detection.bbox.doa_with(det_item->bbox); distance < doa_threshold) {
-                        m.push_back(track_map {det_item, track_item.operator->(), distance});
+                        // Add to the permutation
+                        permutation.push_back(track_map{det_item, track_item.operator->(), distance});
                     }
                 }
-                ++track_item;
+
             }
-            else {
-                historical_items.push_front(*track_item);
-                track_item = current_items.erase(track_item);
-            }
+            ++track_item;
+        }
+        else {
+            /* If it hasn't been seen, it doesn't need to be processed for the tracking anymore.
+             * So it can be moved to the other list only for counting and historical queries. */
+            historical_items.push_front(*track_item);
+            track_item = current_items.erase(track_item);
         }
     }
-    std::sort(m.begin(), m.end(), [](const track_map& a, const track_map& b) {
-        return a.distance < b.distance;
-    });
+    // Sort the permutation by distances. Smaller is a better match.
+    std_sort(permutation, [](const track_map& a, const track_map& b) { return a.distance < b.distance; });
 
     std::vector<const tracked_detection*> result;
     result.reserve(detections.size());
-    while(!m.empty()) {
-        const auto [d, t, distance] = m.front();
+    while(!permutation.empty()) {
+        /* Capture the front of permutation (the least distant ones) and add it to the result.
+         * Each time a permutation is captured, each of the pair should be removed from the rest of the permutation */
+        const auto [d, t, distance] = permutation.front();
+
+        // Let's update the tracked information with the newly detected item.
+
         ++t->smoothed;
         if (t->smoothed > bbox_smooth_rate)
             t->smoothed = bbox_smooth_rate;
+        // To make the bounding boxes move smoothly, we can average out their boxes
         t->last_detection.bbox = t->last_detection.bbox.average_with(static_cast<float>(t->smoothed-1), 1, d->bbox);
         t->last_detection.prob = d->prob;
         t->seen_last = now;
         result.emplace_back(t);
 
-        m.erase(std::remove_if(m.begin(), m.end(), [&](const track_map& items) {
-            return items.t == t;
-        }), m.end());
-        m.erase(std::remove_if(m.begin(), m.end(), [&](const track_map& items) {
-            return items.det == d;
-        }), m.end());;
-        detections_ptr.erase(std::remove_if(detections_ptr.begin(), detections_ptr.end(), [&](const detection* item) {
-            return item == d;
-        }), detections_ptr.end());
+        // Remove each pair from the permutation and the list of detected items, so we don't process them again.
+        std_erase(permutation, [&](const track_map& items) { return items.t == t; });
+        std_erase(permutation, [&](const track_map& items) { return items.det == d; });
+        std_erase(detections_ptr, [&](const detection* item) { return item == d; });
     }
 
+    /* In case there is still a detected item that we haven't found it already, it is new.
+     * Let's welcome it to the family! */
     for (auto& d: detections_ptr) {
         auto item = tracked_detection(count() + 1, *d, now);
         current_items.push_front(item);
@@ -78,22 +106,14 @@ std::vector<const tracked_detection*> tracker::track(const std::vector<detection
 }
 
 uint32_t tracker::count(const uint32_t c) const {
-    const auto c1 = std::count_if(current_items.begin(), current_items.end(), [&](const tracked_detection& item) {
-        return item.last_detection.c == c;
-    });
-    const auto c2 = std::count_if(historical_items.begin(), historical_items.end(), [&](const tracked_detection& item) {
-        return item.last_detection.c == c;
-    });
+    const auto c1 = std_count_if(current_items, [&](const tracked_detection& item) { return item.last_detection.c == c; });
+    const auto c2 = std_count_if(historical_items, [&](const tracked_detection& item) { return item.last_detection.c == c; });
     return c1 + c2;
 }
 
 uint32_t tracker::count(const float duration) const {
     const auto now = std::chrono::system_clock::now();
-    const auto c1 = std::count_if(current_items.begin(), current_items.end(), [&](const tracked_detection& item) {
-        return std::chrono::duration<double>(now - item.seen_last).count() < duration;
-    });
-    const auto c2 = std::count_if(historical_items.begin(), historical_items.end(), [&](const tracked_detection& item) {
-        return std::chrono::duration<double>(now - item.seen_last).count() < duration;
-    });
+    const auto c1 = std_count_if(current_items, [&](const tracked_detection& item) { return get_duration(now, item.seen_last) < duration; });
+    const auto c2 = std_count_if(historical_items, [&](const tracked_detection& item) { return get_duration(now, item.seen_last) < duration; });
     return c1 + c2;
 }

--- a/gst-plugin/src/tracker.cpp
+++ b/gst-plugin/src/tracker.cpp
@@ -13,27 +13,32 @@ std::string to_string(const tracking_time& time) {
 }
 
 struct track_map {
-    detection* det;
+    const detection* det;
     tracked_detection* t;
     float distance;
 };
 
-std::vector<tracked_detection*> tracker::track(std::vector<detection> detections) {
+std::vector<const tracked_detection*> tracker::track(const std::vector<detection>& detections) {
     const auto now = std::chrono::system_clock::now();
+    std::vector<const detection*> detections_ptr;
+    detections_ptr.reserve(detections.size());
+    for(const auto& d: detections)
+        detections_ptr.push_back(&d);
 
     std::vector<track_map> m;
-    for(auto& det_item: detections) {
-        for(auto track_item = current_items.begin(); track_item != current_items.end(); ++track_item) {
+    for(auto& det_item: detections_ptr) {
+        for(auto track_item = current_items.begin(); track_item != current_items.end();) {
             if(std::chrono::duration<double>(now - track_item->seen_last).count() < time_threshold) {
-                if(track_item->last_detection.c == det_item.c) {
-                    if (const auto distance = track_item->last_detection.bbox.doa_with(det_item.bbox); distance < doa_threshold) {
-                        m.push_back(track_map {&det_item, track_item.operator->(), distance});
+                if(track_item->last_detection.c == det_item->c) {
+                    if (const auto distance = track_item->last_detection.bbox.doa_with(det_item->bbox); distance < doa_threshold) {
+                        m.push_back(track_map {det_item, track_item.operator->(), distance});
                     }
                 }
+                ++track_item;
             }
             else {
                 historical_items.push_front(*track_item);
-                current_items.erase(track_item);
+                track_item = current_items.erase(track_item);
             }
         }
     }
@@ -41,9 +46,10 @@ std::vector<tracked_detection*> tracker::track(std::vector<detection> detections
         return a.distance < b.distance;
     });
 
-    std::vector<tracked_detection*> result;
+    std::vector<const tracked_detection*> result;
+    result.reserve(detections.size());
     while(!m.empty()) {
-        const auto& [d, t, distance] = m.front();
+        const auto [d, t, distance] = m.front();
         ++t->smoothed;
         if (t->smoothed > bbox_smooth_rate)
             t->smoothed = bbox_smooth_rate;
@@ -52,15 +58,21 @@ std::vector<tracked_detection*> tracker::track(std::vector<detection> detections
         t->seen_last = now;
         result.emplace_back(t);
 
-        m.erase(std::remove_if(m.begin(), m.end(), [&](const track_map& items) { return &items.t == &t; }), m.end());
-        m.erase(std::remove_if(m.begin(), m.end(), [&](const track_map& items) { return &items.det == &d; }), m.end());;
-        detections.erase(std::remove_if(detections.begin(), detections.end(), [&](const detection& item) { return &item == d; }), detections.end());
+        m.erase(std::remove_if(m.begin(), m.end(), [&](const track_map& items) {
+            return items.t == t;
+        }), m.end());
+        m.erase(std::remove_if(m.begin(), m.end(), [&](const track_map& items) {
+            return items.det == d;
+        }), m.end());;
+        detections_ptr.erase(std::remove_if(detections_ptr.begin(), detections_ptr.end(), [&](const detection* item) {
+            return item == d;
+        }), detections_ptr.end());
     }
 
-    for (auto& d: detections) {
-        auto item = tracked_detection(count() + 1, d, now);
+    for (auto& d: detections_ptr) {
+        auto item = tracked_detection(count() + 1, *d, now);
         current_items.push_front(item);
-        result.emplace_back(&item);
+        result.emplace_back(&current_items.front());
     }
     return result;
 }

--- a/gst-plugin/src/tracker.h
+++ b/gst-plugin/src/tracker.h
@@ -47,7 +47,7 @@ public:
         active(active), time_threshold(time_threshold), doa_threshold(doa_threshold),
         bbox_smooth_rate(bbox_smooth_rate) {}
 
-    [[nodiscard]] std::vector<tracked_detection*> track(std::vector<detection> detections);
+    [[nodiscard]] std::vector<const tracked_detection*> track(const std::vector<detection>& detections);
     [[nodiscard]] uint32_t count() const { return current_items.size() + historical_items.size(); }
     [[nodiscard]] uint32_t count(uint32_t c) const;
     [[nodiscard]] uint32_t count(float duration) const;

--- a/gst-plugin/src/tracker.h
+++ b/gst-plugin/src/tracker.h
@@ -47,13 +47,22 @@ public:
         active(active), time_threshold(time_threshold), doa_threshold(doa_threshold),
         bbox_smooth_rate(bbox_smooth_rate) {}
 
+    /** @brief Track detected items based on previous detections
+     *  @param detections A list of detected items in one frame
+     *  @returns A list of items corresponding to detections that were present earlier.
+     *           The order of items in the output list is not the same as the input list. */
     [[nodiscard]] std::vector<const tracked_detection*> track(const std::vector<detection>& detections);
+
     [[nodiscard]] uint32_t count() const { return current_items.size() + historical_items.size(); }
     [[nodiscard]] uint32_t count(uint32_t c) const;
     [[nodiscard]] uint32_t count(float duration) const;
 
 private:
+    /** List of tracked items that are still visible (t < time_threshold)
+     * They will be used for tracking process */
     std::list<tracked_detection> current_items;
+    /** List of tracked items that are gone (t > time_threshold)
+     * They can be used to query the history and counting. */
     std::list<tracked_detection> historical_items;
 };
 

--- a/gst-plugin/src/tracker.h
+++ b/gst-plugin/src/tracker.h
@@ -8,6 +8,7 @@
 #include "box.h"
 #include <chrono>
 #include <list>
+#include <vector>
 
 using tracking_time = std::chrono::time_point<std::chrono::system_clock>;
 std::string to_string(const tracking_time& time);

--- a/gst-plugin/src/tracker.h
+++ b/gst-plugin/src/tracker.h
@@ -46,13 +46,14 @@ public:
         active(active), time_threshold(time_threshold), doa_threshold(doa_threshold),
         bbox_smooth_rate(bbox_smooth_rate) {}
 
-    [[nodiscard]] tracked_detection& track(const detection& det);
-    [[nodiscard]] uint32_t count() const { return items.size(); }
+    [[nodiscard]] std::vector<tracked_detection*> track(std::vector<detection> detections);
+    [[nodiscard]] uint32_t count() const { return current_items.size() + historical_items.size(); }
     [[nodiscard]] uint32_t count(uint32_t c) const;
     [[nodiscard]] uint32_t count(float duration) const;
 
 private:
-    std::list<tracked_detection> items;
+    std::list<tracked_detection> current_items;
+    std::list<tracked_detection> historical_items;
 };
 
 

--- a/gst-plugin/tests/meson.build
+++ b/gst-plugin/tests/meson.build
@@ -1,0 +1,10 @@
+tracker_test_sources = [
+    '../src/tracker.cpp',
+    '../src/box.cpp',
+    'tracker_test.cpp'
+]
+
+e = executable('tracker_test', tracker_test_sources, dependencies: [thread_dep])
+test('Tracking Add', e)
+test('Tracking DOA', e, args: ['doa'])
+test('Tracking Time', e, args: ['time'])

--- a/gst-plugin/tests/tracker_test.cpp
+++ b/gst-plugin/tests/tracker_test.cpp
@@ -1,0 +1,62 @@
+//
+// Created by matin on 25/12/23.
+//
+
+#include "../src/tracker.h"
+#include <thread>
+#include <chrono>
+#include <cassert>
+#include <algorithm>
+
+enum ARG {
+    ARG_NONE,
+    ARG_UNKNOWN,
+    ARG_DOA,
+    ARG_TIME
+};
+ARG string_hash(int argc, char** argv) {
+    if (argc == 1) return ARG_NONE;
+    auto str = std::string(argv[1]);
+    if (str == "doa") return ARG_DOA;
+    if (str == "time") return ARG_TIME;
+    return ARG_UNKNOWN;
+}
+
+int main(int argc, char** argv) {
+    ARG arg = string_hash(argc, argv);
+    assert(arg != ARG_UNKNOWN);
+
+    tracker t(true, 1, 2.25, 1);
+
+    std::vector<detection> detections = {
+            detection{Box{100, 100, 20, 20}, 1, 1, "name"},
+            detection{Box{200, 100, 20, 20}, 2, 1, "name"},
+            detection{Box{100, 200, 20, 20}, 1, 1, "name"},
+    };
+    auto result_ptr = t.track(detections);
+    std::vector<tracked_detection> result;
+    result.reserve(result_ptr.size());
+    for (const auto r: result_ptr) result.push_back(*r);
+
+    if (arg == ARG_DOA || arg == ARG_TIME) {
+
+        if (arg == ARG_TIME) std::this_thread::sleep_for(std::chrono::seconds(2));
+
+        detections = {
+                detection{Box{202, 101, 20, 20}, 2, 1, "name"},
+                detection{Box{102, 201, 20, 20}, 1, 1, "name"},
+                detection{Box{101, 105, 20, 20}, 1, 1, "name"},
+        };
+
+        auto result_later = t.track(detections);
+        std::sort(result_later.begin(), result_later.end(),
+                  [](const tracked_detection* a, const tracked_detection* b) { return a->id < b->id; });
+
+        for (std::size_t i = 0; i < detections.size(); i++)
+            if (arg == ARG_DOA) assert(result_later.at(i)->id == result.at(i).id);
+            else                assert(result_later.at(i)->id != result.at(i).id);
+
+    }
+
+    return 0;
+}


### PR DESCRIPTION
In this pull request, I reimplement the tracking algorithm.

 - I create a permutation of "newly detected items" and "previously tracked items" and I calculate the distance of each.
Then, I sort the distances. 
The least distance should be the one that matches correctly.

- I also make sure that I am not matching one item multiple times. I remove calculated ones from the vector of items that are being processed.

- To make sure that the algorithm is working correctly, I created a unit case for myself to trace and debug. So I am much more confident about this one.