### PR TITLE
Read the DRPAI input format instead of hardcoding

### DIFF
--- a/gst-plugin/src/drpai-models/drpai_connection.cpp
+++ b/gst-plugin/src/drpai-models/drpai_connection.cpp
@@ -318,17 +318,17 @@ void DRPAI_Connection::read_data_in_list(const std::string &data_in_list) {
         if (line.find("Height") != std::string::npos) {
             const auto pos = line.find(':') + 2;
             IN_WIDTH = std::stoi(line.substr(pos));
-            std::cout << "\t" << IN_WIDTH;
+            std::cout << " " << IN_WIDTH;
         }
         if (line.find("Width") != std::string::npos) {
             const auto pos = line.find(':') + 2;
             IN_HEIGHT = std::stoi(line.substr(pos));
-            std::cout << "\t" << IN_HEIGHT;
+            std::cout << " " << IN_HEIGHT;
         }
         if (line.find("Channel") != std::string::npos) {
             const auto pos = line.find(':') + 2;
             IN_CHANNEL = std::stoi(line.substr(pos));
-            std::cout << "\t" << IN_CHANNEL;
+            std::cout << " " << IN_CHANNEL;
         }
         if (line.find("Input_node_name") != std::string::npos) {
             const auto pos = line.find(':') + 2;
@@ -339,7 +339,7 @@ void DRPAI_Connection::read_data_in_list(const std::string &data_in_list) {
                 IN_FORMAT = YUV_DATA;
             else
                 throw std::runtime_error("[ERROR] DRP-AI data in format unsupported: " + value);
-            std::cout << "\t" << value;
+            std::cout << " " << value;
         }
     }
     infile.close();

--- a/gst-plugin/src/drpai-models/drpai_connection.cpp
+++ b/gst-plugin/src/drpai-models/drpai_connection.cpp
@@ -266,8 +266,15 @@ void DRPAI_Connection::open_resource(const uint32_t data_in_address) {
     read_addrmap_txt(drpai_address_file);
     drpai_output_buf.resize(drpai_address.data_out_size/sizeof(float));
 
+    /*Load pixel format from data_in_list file*/
+    const static std::string data_in_list = prefix + "/" + prefix + "_data_in_list.txt";
+    std::cout << "Loading : " << data_in_list << std::endl;
+    read_data_in_list(data_in_list);
+    if (filter_region.w == 0)
+        filter_region = {0, 0, static_cast<float>(IN_WIDTH), static_cast<float>(IN_HEIGHT)};
+
     post_process.dynamic_library_open(prefix);
-    if (post_process.post_process_initialize(prefix.c_str(), drpai_output_buf.size()) != 0)
+    if (post_process.post_process_initialize(prefix.c_str(), IN_WIDTH, IN_HEIGHT, drpai_output_buf.size()) != 0)
         throw std::runtime_error("[ERROR] Failed to run post_process_initialize.");
 
     /* Open DRP-AI Driver */
@@ -294,6 +301,47 @@ void DRPAI_Connection::open_resource(const uint32_t data_in_address) {
     proc[DRPAI_INDEX_WEIGHT].size         = drpai_address.weight_size;
     proc[DRPAI_INDEX_OUTPUT].address      = drpai_address.data_out_addr;
     proc[DRPAI_INDEX_OUTPUT].size         = drpai_address.data_out_size;
+}
+
+void DRPAI_Connection::read_data_in_list(const std::string &data_in_list) {
+    std::ifstream infile(data_in_list);
+
+    if (!infile.is_open())
+        throw std::runtime_error("[ERROR] Failed to load data in file: " + data_in_list);
+
+    std::string line;
+    while (getline(infile,line))
+    {
+        if (infile.fail())
+            throw std::runtime_error("[ERROR] Failed to load data in file: " + data_in_list);
+        if (line.find("Width") != std::string::npos) {
+            const auto pos = line.find(':') + 2;
+            IN_WIDTH = std::stoi(line.substr(pos));
+        }
+        if (line.find("Height") != std::string::npos) {
+            const auto pos = line.find(':') + 2;
+            IN_WIDTH = std::stoi(line.substr(pos));
+        }
+        if (line.find("Width") != std::string::npos) {
+            const auto pos = line.find(':') + 2;
+            IN_HEIGHT = std::stoi(line.substr(pos));
+        }
+        if (line.find("Channel") != std::string::npos) {
+            const auto pos = line.find(':') + 2;
+            IN_CHANNEL = std::stoi(line.substr(pos));
+        }
+        if (line.find("Input_node_name") != std::string::npos) {
+            const auto pos = line.find(':') + 2;
+            const auto value = line.substr(pos);
+            if (value == "bgr_data")
+                IN_FORMAT = BGR_DATA;
+            else if (value == "yuv_data")
+                IN_FORMAT = YUV_DATA;
+            else
+                throw std::runtime_error("[ERROR] DRP-AI data in format unsupported: " + value);
+        }
+    }
+    infile.close();
 }
 
 void DRPAI_Connection::release_resource() {

--- a/gst-plugin/src/drpai-models/drpai_connection.cpp
+++ b/gst-plugin/src/drpai-models/drpai_connection.cpp
@@ -19,6 +19,7 @@
 ******************************************/
 void DRPAI_Connection::read_addrmap_txt(const std::string& addr_file)
 {
+    std::cout << "Loading : " << addr_file << std::endl;
     std::ifstream ifs(addr_file);
     if (ifs.fail())
         throw std::runtime_error("[ERROR] Failed to open address map list : " + addr_file);
@@ -262,13 +263,11 @@ void DRPAI_Connection::wait() const {
 
 void DRPAI_Connection::open_resource(const uint32_t data_in_address) {
     const std::string drpai_address_file = prefix + "/" + prefix + "_addrmap_intm.txt";
-    std::cout << "Loading : " << drpai_address_file << std::endl;
     read_addrmap_txt(drpai_address_file);
     drpai_output_buf.resize(drpai_address.data_out_size/sizeof(float));
 
     /*Load pixel format from data_in_list file*/
     const static std::string data_in_list = prefix + "/" + prefix + "_data_in_list.txt";
-    std::cout << "Loading : " << data_in_list << std::endl;
     read_data_in_list(data_in_list);
     if (filter_region.w == 0)
         filter_region = {0, 0, static_cast<float>(IN_WIDTH), static_cast<float>(IN_HEIGHT)};
@@ -304,31 +303,32 @@ void DRPAI_Connection::open_resource(const uint32_t data_in_address) {
 }
 
 void DRPAI_Connection::read_data_in_list(const std::string &data_in_list) {
+    std::cout << "Loading : " << data_in_list << std::flush;
     std::ifstream infile(data_in_list);
 
     if (!infile.is_open())
         throw std::runtime_error("[ERROR] Failed to load data in file: " + data_in_list);
 
+    std::cout << "\t\tFound input type:";
     std::string line;
     while (getline(infile,line))
     {
         if (infile.fail())
             throw std::runtime_error("[ERROR] Failed to load data in file: " + data_in_list);
-        if (line.find("Width") != std::string::npos) {
-            const auto pos = line.find(':') + 2;
-            IN_WIDTH = std::stoi(line.substr(pos));
-        }
         if (line.find("Height") != std::string::npos) {
             const auto pos = line.find(':') + 2;
             IN_WIDTH = std::stoi(line.substr(pos));
+            std::cout << "\t" << IN_WIDTH;
         }
         if (line.find("Width") != std::string::npos) {
             const auto pos = line.find(':') + 2;
             IN_HEIGHT = std::stoi(line.substr(pos));
+            std::cout << "\t" << IN_HEIGHT;
         }
         if (line.find("Channel") != std::string::npos) {
             const auto pos = line.find(':') + 2;
             IN_CHANNEL = std::stoi(line.substr(pos));
+            std::cout << "\t" << IN_CHANNEL;
         }
         if (line.find("Input_node_name") != std::string::npos) {
             const auto pos = line.find(':') + 2;
@@ -339,9 +339,11 @@ void DRPAI_Connection::read_data_in_list(const std::string &data_in_list) {
                 IN_FORMAT = YUV_DATA;
             else
                 throw std::runtime_error("[ERROR] DRP-AI data in format unsupported: " + value);
+            std::cout << "\t" << value;
         }
     }
     infile.close();
+    std::cout << std::endl;
 }
 
 void DRPAI_Connection::release_resource() {

--- a/gst-plugin/src/drpai-models/drpai_connection.h
+++ b/gst-plugin/src/drpai-models/drpai_connection.h
@@ -38,16 +38,17 @@ typedef struct
 class DRPAI_Connection {
 
 public:
-    fps rate{};
+    fps rate {};
     std::string prefix {};
     std::vector<detection> last_det {};
-    Box filter_region;
+    Box filter_region {};
     std::vector<std::string> corner_text {};
 
     /*DRP-AI Input image information*/
-    int32_t IN_WIDTH;
-    int32_t IN_HEIGHT;
-    int32_t IN_CHANNEL;
+    int32_t IN_WIDTH = 0;
+    int32_t IN_HEIGHT = 0;
+    int32_t IN_CHANNEL = 0;
+    IMAGE_FORMAT IN_FORMAT = BGR_DATA;
 
     virtual void run_inference();
     virtual void open_resource(uint32_t data_in_address);
@@ -66,15 +67,9 @@ protected:
 
     constexpr static float TH_NMS = 0.5f;
 
-    explicit DRPAI_Connection(const int32_t IN_WIDTH, const int32_t IN_HEIGHT, const int32_t IN_CHANNEL):
-        filter_region{ 0, 0, static_cast<float>(IN_WIDTH), static_cast<float>(IN_HEIGHT)},
-        IN_WIDTH(IN_WIDTH), IN_HEIGHT(IN_HEIGHT), IN_CHANNEL(IN_CHANNEL)
-    {};
+    explicit DRPAI_Connection() {};
     virtual ~DRPAI_Connection() = default;
 
-    void read_addrmap_txt(const std::string& addr_file);
-    void load_drpai_data() const;
-    void load_data_to_mem(const std::string& data, uint32_t from, uint32_t size) const;
     void load_drpai_param_file(const drpai_data_t& proc, const std::string& param_file, uint32_t file_size) const;
     void get_result();
     void start();
@@ -88,6 +83,11 @@ private:
     enum DRPAI_INDEX {
         INDEX_D=0, INDEX_C, INDEX_P, INDEX_A, INDEX_W
     };
+
+    void read_addrmap_txt(const std::string& addr_file);
+    void read_data_in_list(const std::string &data_in_list);
+    void load_drpai_data() const;
+    void load_data_to_mem(const std::string& data, uint32_t from, uint32_t size) const;
 };
 
 

--- a/gst-plugin/src/drpai-models/drpai_yolo.h
+++ b/gst-plugin/src/drpai-models/drpai_yolo.h
@@ -12,7 +12,6 @@ class DRPAI_Yolo final: public DRPAI_Connection {
 
 public:
     explicit DRPAI_Yolo(const bool log_detects):
-            DRPAI_Connection(640, 480, 3),
             log_detects(log_detects),
             det_tracker(true, 2, 2.25, 1)
     {}

--- a/gst-plugin/src/drpai_controller.cpp
+++ b/gst-plugin/src/drpai_controller.cpp
@@ -41,9 +41,6 @@ void DRPAI_Controller::open_resources() {
     /* Filter the bit higher than 32 bit */
     udmabuf_address &=0xFFFFFFFF;
 
-    image_mapped_udma = std::make_unique<Image>(drpai.IN_WIDTH, drpai.IN_HEIGHT, drpai.IN_CHANNEL, drpai.IN_FORMAT, nullptr);
-    image_mapped_udma->map_udmabuf();
-
     /**********************************************************************/
     /* Inference preparation                                              */
     /**********************************************************************/
@@ -51,6 +48,8 @@ void DRPAI_Controller::open_resources() {
     /* Read DRP-AI Object files address and size */
     drpai.open_resource(udmabuf_address);
 
+    image_mapped_udma = std::make_unique<Image>(drpai.IN_WIDTH, drpai.IN_HEIGHT, drpai.IN_CHANNEL, drpai.IN_FORMAT, nullptr);
+    image_mapped_udma->map_udmabuf();
 
     std::cout <<"DRP-AI Ready!" << std::endl;
 }

--- a/gst-plugin/src/drpai_controller.cpp
+++ b/gst-plugin/src/drpai_controller.cpp
@@ -21,7 +21,7 @@ void DRPAI_Controller::open_resources() {
     std::cout << "RZ/V2L DRP-AI Plugin" << std::endl;
 
     if (multithread)
-        process_thread = new std::thread(&DRPAI_Controller::thread_function_loop, this);
+        process_thread = std::make_unique<std::thread>(&DRPAI_Controller::thread_function_loop, this);
     else
         thread_state = Ready;
 
@@ -41,7 +41,8 @@ void DRPAI_Controller::open_resources() {
     /* Filter the bit higher than 32 bit */
     udmabuf_address &=0xFFFFFFFF;
 
-    image_mapped_udma.map_udmabuf();
+    image_mapped_udma = std::make_unique<Image>(drpai.IN_WIDTH, drpai.IN_HEIGHT, drpai.IN_CHANNEL, drpai.IN_FORMAT, nullptr);
+    image_mapped_udma->map_udmabuf();
 
     /**********************************************************************/
     /* Inference preparation                                              */
@@ -63,7 +64,7 @@ void DRPAI_Controller::process_image(uint8_t* img_data) {
                 throw std::exception();
 
             case Ready:
-                image_mapped_udma.copy(img_data);
+                image_mapped_udma->copy(img_data, BGR_DATA);
                 //std::this_thread::sleep_for(std::chrono::milliseconds(50));
                 thread_state = Processing;
                 if (multithread)
@@ -85,7 +86,7 @@ void DRPAI_Controller::process_image(uint8_t* img_data) {
             throw;
         }
 
-    Image img (drpai.IN_WIDTH, drpai.IN_HEIGHT, 3, img_data);
+    Image img (drpai.IN_WIDTH, drpai.IN_HEIGHT, 3, BGR_DATA, img_data);
     video_rate.inform_frame();
 
     /* Compute the result, draw the result on img and display it on console */
@@ -106,10 +107,11 @@ void DRPAI_Controller::release_resources() {
             v.notify_one();
         }
         process_thread->join();
-        delete process_thread;
+        process_thread.reset();
     }
 
     drpai.release_resource();
+    image_mapped_udma.reset();
 }
 
 void DRPAI_Controller::thread_function_loop() {

--- a/gst-plugin/src/drpai_controller.cpp
+++ b/gst-plugin/src/drpai_controller.cpp
@@ -143,5 +143,6 @@ void DRPAI_Controller::thread_function_single() {
         }
     }
 
+    image_mapped_udma->prepare();
     drpai.run_inference();
 }

--- a/gst-plugin/src/drpai_controller.h
+++ b/gst-plugin/src/drpai_controller.h
@@ -20,8 +20,7 @@ class DRPAI_Controller {
 
 public:
     explicit DRPAI_Controller():
-            drpai(false),
-            image_mapped_udma(drpai.IN_WIDTH, drpai.IN_HEIGHT, drpai.IN_CHANNEL, nullptr)
+            drpai(false)
     {}
 
     bool multithread = true;
@@ -34,12 +33,12 @@ public:
     void process_image(uint8_t* img_data);
 
 private:
-    Image image_mapped_udma;
+    std::unique_ptr<Image> image_mapped_udma = nullptr;
 
     /* Thread Section */
     enum ThreadState { Unknown, Ready, Processing, Failed, Closing };
     ThreadState thread_state = Unknown;
-    std::thread* process_thread = nullptr;
+    std::unique_ptr<std::thread> process_thread = nullptr;
     std::mutex state_mutex;
     std::condition_variable v;
     void thread_function_loop();

--- a/gst-plugin/src/dynamic-post-process/postprocess.h
+++ b/gst-plugin/src/dynamic-post-process/postprocess.h
@@ -56,7 +56,7 @@ public:
         return 0;
     }
 
-    int8_t EXPORT(post_process_initialize) (const char model_prefix[], uint32_t output_len);
+    int8_t EXPORT(post_process_initialize) (const char model_prefix[], uint32_t in_width, uint32_t in_height, uint32_t output_len);
     int8_t EXPORT(post_process_release) ();
     int8_t EXPORT(post_process_output) (const float output_buf[], struct detection det[], uint8_t *det_len);
 

--- a/gst-plugin/src/dynamic-post-process/yolo/yolo.cpp
+++ b/gst-plugin/src/dynamic-post-process/yolo/yolo.cpp
@@ -15,6 +15,8 @@ static std::vector<std::string> labels {};
 static std::vector<float> anchors {};
 static std::vector<uint32_t> num_grids {};
 static uint32_t num_bb = 0;
+static uint32_t IN_WIDTH = 0;
+static uint32_t IN_HEIGHT = 0;
 static BEST_CLASS_PREDICTION_ALGORITHM best_class_prediction_algorithm = BEST_CLASS_PREDICTION_ALGORITHM_NONE;
 static ANCHOR_DIVIDE_SIZE anchor_divide_size = ANCHOR_DIVIDE_SIZE_NONE;
 
@@ -147,7 +149,9 @@ int8_t load_num_grids(const std::string& data_out_list_file_name)
     return 0;
 }
 
-int8_t post_process_initialize(const char model_prefix[], const uint32_t output_len) {
+int8_t post_process_initialize(const char model_prefix[], uint32_t in_width, uint32_t in_height, uint32_t output_len) {
+    IN_WIDTH = in_width;
+    IN_HEIGHT = in_height;
     const std::string prefix { model_prefix };
     post_process_release();
 

--- a/gst-plugin/src/dynamic-post-process/yolo/yolo.h
+++ b/gst-plugin/src/dynamic-post-process/yolo/yolo.h
@@ -5,8 +5,6 @@
 #ifndef GSTREAMER1_0_DRPAI_YOLO_H
 #define GSTREAMER1_0_DRPAI_YOLO_H
 
-constexpr int32_t IN_WIDTH        = 640;
-constexpr int32_t IN_HEIGHT       = 480;
 constexpr float   TH_PROB         = 0.5f;
 constexpr int32_t MODEL_IN_W      = 416;
 constexpr int32_t MODEL_IN_H      = 416;

--- a/gst-plugin/src/gstdrpai.cpp
+++ b/gst-plugin/src/gstdrpai.cpp
@@ -257,7 +257,7 @@ gst_drpai_change_state (GstElement * element, const GstStateChange transition) {
                 obj->drpai_controller->open_resources();
             }
             catch (std::runtime_error &e) {
-                std::cerr << e.what() << std::endl;
+                std::cerr << std::endl << e.what() << std::endl << std::endl;
                 if (obj->stop_error)
                     return GST_STATE_CHANGE_FAILURE;
             }
@@ -275,7 +275,7 @@ gst_drpai_change_state (GstElement * element, const GstStateChange transition) {
                 obj->drpai_controller->release_resources();
             }
             catch (std::runtime_error &e) {
-                std::cerr << e.what() << std::endl;
+                std::cerr << std::endl << e.what() << std::endl << std::endl;
                 state_change_ret = GST_STATE_CHANGE_FAILURE;
             }
             delete obj->drpai_controller;
@@ -477,7 +477,7 @@ gst_drpai_chain(GstPad *pad, GstObject *parent, GstBuffer *buf) {
         obj->drpai_controller->process_image(info.data);
     }
     catch (const std::exception& e) {
-        std::cerr << e.what() << std::endl;
+        std::cerr << std::endl << e.what() << std::endl << std::endl;
         if(obj->stop_error) {
             gst_buffer_unref (buf);
             return GST_FLOW_ERROR;

--- a/gst-plugin/src/image.cpp
+++ b/gst-plugin/src/image.cpp
@@ -81,9 +81,10 @@ void Image::copy(const uint8_t* data, IMAGE_FORMAT f) {
     if (format == f)
         std::memcpy(img_buffer, data, size);
     else if(format == YUV_DATA && f == BGR_DATA) {
+        const uint32_t s = img_w * img_h * BGR_NUM_CHANNEL;
         if (convert_buffer == nullptr)
-            convert_buffer = std::make_unique<uint8_t>(size);
-        std::memcpy(convert_buffer.get(), data, size);
+            convert_buffer = std::make_unique<uint8_t>(s);
+        std::memcpy(convert_buffer.get(), data, s);
         convert_from_format = f;
     } else
         throw std::runtime_error("[ERROR] Can't convert image formats.");
@@ -289,13 +290,13 @@ void Image::copy_convert_bgr_to_yuy2(const uint8_t* data) const {
         return;
 
     for (int y = 0; y < img_h; ++y) {
-        const auto& bgrRow = &data[3 * img_w * y];
-        const auto& yuy2Row = &img_buffer[2 * img_w * y];
+        const auto& bgrRow = &data[BGR_NUM_CHANNEL * img_w * y];
+        const auto& yuy2Row = &img_buffer[YUV2_NUM_CHANNEL * img_w * y];
 
         for (int x = 0; x < img_w; x += 2) {
             // Convert two BGR pixels to YUY2 format
-            const auto bgrIdx1 = 3 * x;
-            const auto bgrIdx2 = 3 * (x + 1);
+            const auto bgrIdx1 = BGR_NUM_CHANNEL * x;
+            const auto bgrIdx2 = BGR_NUM_CHANNEL * (x + 1);
 
             const auto& b1 = bgrRow[bgrIdx1];
             const auto& g1 = bgrRow[bgrIdx1 + 1];
@@ -316,10 +317,10 @@ void Image::copy_convert_bgr_to_yuy2(const uint8_t* data) const {
             // const auto v2 = static_cast<uint8_t>(0.615 * r2 - 0.51498 * g2 - 0.10001 * b2 + 128);
 
             // Pack the Y, U, and Y, V values into a 32-bit word
-            yuy2Row[2 * x] = y1;
-            yuy2Row[2 * x + 1] = u1;
-            yuy2Row[2 * x + 2] = y2;
-            yuy2Row[2 * x + 3] = v1;
+            yuy2Row[YUV2_NUM_CHANNEL * x] = y1;
+            yuy2Row[YUV2_NUM_CHANNEL * x + 1] = u1;
+            yuy2Row[YUV2_NUM_CHANNEL * x + 2] = y2;
+            yuy2Row[YUV2_NUM_CHANNEL * x + 3] = v1;
         }
     }
 }

--- a/gst-plugin/src/image.cpp
+++ b/gst-plugin/src/image.cpp
@@ -326,9 +326,9 @@ void Image::copy_convert_bgr_to_yuy2(const uint8_t* data) const {
 
 void Image::prepare() {
     if (convert_buffer != nullptr) {
-        if (convert_from_format == YUV_DATA && format == BGR_DATA) {
+        if (convert_from_format == BGR_DATA && format == YUV_DATA) {
             copy_convert_bgr_to_yuy2(convert_buffer.get());
-            convert_from_format = BGR_DATA;
+            convert_from_format = format;
         }
     }
 }

--- a/gst-plugin/src/image.cpp
+++ b/gst-plugin/src/image.cpp
@@ -74,9 +74,16 @@ void Image::map_udmabuf()
     }
 }
 
-void Image::copy(const uint8_t* data) const {
-    if(img_buffer != nullptr)
+void Image::copy(const uint8_t* data, IMAGE_FORMAT f) const {
+    if(img_buffer == nullptr)
+        return;
+
+    if (format == f)
         std::memcpy(img_buffer, data, size);
+    else if(format == YUV_DATA && f == BGR_DATA)
+        copy_convert_bgr_to_yuy2(data);
+    else
+        throw std::runtime_error("[ERROR] Can't convert image formats.");
 }
 
 /*****************************************

--- a/gst-plugin/src/image.h
+++ b/gst-plugin/src/image.h
@@ -66,8 +66,8 @@ class Image
         constexpr static uint32_t BGR_NUM_CHANNEL = 3;
         constexpr static uint32_t YUV2_NUM_CHANNEL = 2;
         IMAGE_FORMAT convert_from_format;
-        std::unique_ptr<uint8_t> convert_buffer = nullptr;
-        void copy_convert_bgr_to_yuy2(const uint8_t* data) const;
+        std::unique_ptr<uint8_t[]> convert_buffer = nullptr;
+        void copy_convert_bgr_to_yuy2() const;
 
         /* drawing section */
         constexpr static uint32_t front_color = RED_DATA;

--- a/gst-plugin/src/image.h
+++ b/gst-plugin/src/image.h
@@ -30,19 +30,24 @@
 constexpr uint32_t RED_DATA   = 0x0000FFu;
 constexpr uint32_t WHITE_DATA = 0xFFFFFFu;
 constexpr uint32_t BLACK_DATA = 0x000000u;
+enum IMAGE_FORMAT {
+    BGR_DATA, YUV_DATA
+};
 
 class Image
 {
     public:
-        explicit Image(const int32_t w, const int32_t h, const int32_t c, uint8_t* data):
-            img_w(w), img_h(h), img_c(c), size(img_w*img_h*img_c), img_buffer(data) {};
+        explicit Image(const int32_t w, const int32_t h, const int32_t c, IMAGE_FORMAT format, uint8_t* data):
+            format(format), img_w(w), img_h(h), img_c(c), size(img_w*img_h*img_c), img_buffer(data) {};
         ~Image();
+
+        IMAGE_FORMAT format;
 
         [[nodiscard]] uint8_t at(const int32_t a) const { return img_buffer[a]; }
         void set(const int32_t a, const uint8_t val) const { img_buffer[a] = val; }
 
         void map_udmabuf();
-        void copy(const uint8_t* data) const;
+        void copy(const uint8_t* data, IMAGE_FORMAT format) const;
         void copy_convert_bgr_to_yuy2(const uint8_t* data) const;
         void copy_convert_bgr_to_yuy2(const Image& img) const { copy_convert_bgr_to_yuy2(img.img_buffer); }
         void draw_rect(const Box& box, const std::string& str) const;

--- a/gst-plugin/src/image.h
+++ b/gst-plugin/src/image.h
@@ -63,6 +63,8 @@ class Image
         uint8_t* img_buffer = nullptr;
 
         /* converting section */
+        constexpr static uint32_t BGR_NUM_CHANNEL = 3;
+        constexpr static uint32_t YUV2_NUM_CHANNEL = 2;
         IMAGE_FORMAT convert_from_format;
         std::unique_ptr<uint8_t> convert_buffer = nullptr;
         void copy_convert_bgr_to_yuy2(const uint8_t* data) const;

--- a/gst-plugin/src/image.h
+++ b/gst-plugin/src/image.h
@@ -25,6 +25,7 @@
 #ifndef IMAGE_H
 #define IMAGE_H
 
+#include <memory>
 #include "box.h"
 
 constexpr uint32_t RED_DATA   = 0x0000FFu;
@@ -38,18 +39,16 @@ class Image
 {
     public:
         explicit Image(const int32_t w, const int32_t h, const int32_t c, IMAGE_FORMAT format, uint8_t* data):
-            format(format), img_w(w), img_h(h), img_c(c), size(img_w*img_h*img_c), img_buffer(data) {};
+            img_w(w), img_h(h), img_c(c), format(format), size(img_w*img_h*img_c), img_buffer(data),
+            convert_from_format(format) {};
         ~Image();
-
-        IMAGE_FORMAT format;
 
         [[nodiscard]] uint8_t at(const int32_t a) const { return img_buffer[a]; }
         void set(const int32_t a, const uint8_t val) const { img_buffer[a] = val; }
 
         void map_udmabuf();
-        void copy(const uint8_t* data, IMAGE_FORMAT format) const;
-        void copy_convert_bgr_to_yuy2(const uint8_t* data) const;
-        void copy_convert_bgr_to_yuy2(const Image& img) const { copy_convert_bgr_to_yuy2(img.img_buffer); }
+        void copy(const uint8_t* data, IMAGE_FORMAT format);
+        void prepare();
         void draw_rect(const Box& box, const std::string& str) const;
         void write_string(const std::string& pcode, int32_t x,  int32_t y,
                           int32_t color, int32_t backcolor, int8_t margin=0) const;
@@ -59,9 +58,16 @@ class Image
         int32_t img_w;
         int32_t img_h;
         int32_t img_c;
+        IMAGE_FORMAT format;
         int32_t size;
         uint8_t* img_buffer = nullptr;
 
+        /* converting section */
+        IMAGE_FORMAT convert_from_format;
+        std::unique_ptr<uint8_t> convert_buffer = nullptr;
+        void copy_convert_bgr_to_yuy2(const uint8_t* data) const;
+
+        /* drawing section */
         constexpr static uint32_t front_color = RED_DATA;
         constexpr static uint32_t back_color = BLACK_DATA;
         constexpr static int32_t font_w = 6;


### PR DESCRIPTION
In this pull request, I stop hardcoding the DRPAI input format.
Instead, I read it from the input model.