### PR TITLE
Add history length

### DIFF
--- a/JSON.md
+++ b/JSON.md
@@ -68,8 +68,9 @@ Here is a sample of JSON output of Yolo models when the tracking is **on**:
                 }
             }
         ],
-        "tracked-count": {
-            "total": 6,
+        "track-history": {
+            "minutes": 60,
+            "total-count": 6,
             "person": 2,
             "wine glass": 3,
             "chair": 1

--- a/gst-plugin/src/drpai-models/drpai_yolo.cpp
+++ b/gst-plugin/src/drpai-models/drpai_yolo.cpp
@@ -108,7 +108,9 @@ void DRPAI_Yolo::render_detections_on_image(Image &img) {
 void DRPAI_Yolo::add_corner_text() {
     DRPAI_Connection::add_corner_text();
     if (det_tracker.active) {
-        corner_text.push_back("Tracked/Hour: " + std::to_string(det_tracker.count(60.0f * 60.0f)));
+        corner_text.push_back(
+                "Tracked/" + std::to_string(static_cast<uint32_t>(det_tracker.history_length)) + "min: " +
+                std::to_string(det_tracker.count()));
     }
 }
 
@@ -126,6 +128,6 @@ json_array DRPAI_Yolo::get_detections_json() const {
 json_object DRPAI_Yolo::get_json() const {
     json_object j = DRPAI_Connection::get_json();
     if(det_tracker.active)
-        j.add("tracked-count", det_tracker.get_json());
+        j.add("track-history", det_tracker.get_json());
     return j;
 }

--- a/gst-plugin/src/gstdrpai.cpp
+++ b/gst-plugin/src/gstdrpai.cpp
@@ -93,6 +93,7 @@ enum {
 
     PROP_TRACK_SECONDS,
     PROP_TRACK_DOA_THRESHOLD,
+    PROP_TRACK_HISTORY_LENGTH,
 
     PROP_FILTER_CLASS,
     PROP_FILTER_LEFT,
@@ -196,6 +197,10 @@ gst_drpai_class_init(GstDRPAIClass *klass) {
         g_param_spec_float("track_doa_thresh", "Track DOA Threshold",
                            "The threshold of Distance Over Areas (DOA) for tracking bounding-boxes.",
                            0.001, 1000, 2.25, G_PARAM_READWRITE));
+    g_object_class_install_property(gobject_class, PROP_TRACK_HISTORY_LENGTH,
+        g_param_spec_float("track_history_length", "Track History Length",
+                           "Minutes to keep the tracking history.",
+                           0, 1440, 60, G_PARAM_READWRITE));
     g_object_class_install_property(gobject_class, PROP_FILTER_CLASS,
         g_param_spec_string("filter_class", "Filter Class",
                             "A comma-separated list of classes to filter the detection.",
@@ -338,6 +343,9 @@ gst_drpai_set_property(GObject *object, const guint prop_id,
         case PROP_TRACK_DOA_THRESHOLD:
             obj->drpai_controller->drpai.det_tracker.doa_threshold = g_value_get_float(value);
             break;
+        case PROP_TRACK_HISTORY_LENGTH:
+            obj->drpai_controller->drpai.det_tracker.history_length = g_value_get_float(value);
+            break;
         case PROP_FILTER_CLASS: {
             const std::string csv_classes = g_value_get_string(value);
             obj->drpai_controller->drpai.filter_classes.clear();
@@ -411,6 +419,9 @@ gst_drpai_get_property(GObject *object, const guint prop_id,
             break;
         case PROP_TRACK_DOA_THRESHOLD:
             g_value_set_float(value, obj->drpai_controller->drpai.det_tracker.doa_threshold);
+            break;
+        case PROP_TRACK_HISTORY_LENGTH:
+            g_value_set_float(value, obj->drpai_controller->drpai.det_tracker.history_length);
             break;
         case PROP_FILTER_CLASS: {
             std::string ss;

--- a/gst-plugin/src/json.h
+++ b/gst-plugin/src/json.h
@@ -52,6 +52,7 @@ public:
     [[nodiscard]] std::string to_string() const override { return "{" + s + "}"; }
 
 private:
+    using json_base::add;
     void add_key(const std::string& key) { add_comma(); s += format_string(key) + ": "; }
 };
 

--- a/gst-plugin/src/tracker.h
+++ b/gst-plugin/src/tracker.h
@@ -38,10 +38,11 @@ public:
     bool active;
     float time_threshold;
     float doa_threshold;
+    float history_length; // Minutes to keep the tracking history.
     uint16_t bbox_smooth_rate;
 
     tracker(const bool active, const float time_threshold, const float doa_threshold, const uint16_t bbox_smooth_rate):
-        active(active), time_threshold(time_threshold), doa_threshold(doa_threshold),
+        active(active), time_threshold(time_threshold), doa_threshold(doa_threshold), history_length(60),
         bbox_smooth_rate(bbox_smooth_rate) {}
 
     /** @brief Track detected items based on previous detections
@@ -51,7 +52,6 @@ public:
     [[nodiscard]] std::vector<const tracked_detection*> track(const std::vector<detection>& detections);
 
     [[nodiscard]] uint32_t count() const { return current_items.size() + historical_items.size(); }
-    [[nodiscard]] uint32_t count(float duration) const;
     [[nodiscard]] json_object get_json() const;
 
 private:


### PR DESCRIPTION
In this pull request, I am adding the new GStreamer property `track-history-length` which is `Minutes to keep the tracking history.` and defaults to 60 minutes.

This number also shows up in JSON output (See `JSON.md`) and the corner `Tracked/60min:`.