### PR TITLE
Add show filter box property + filter geometry fixes

### DIFF
--- a/JSON.md
+++ b/JSON.md
@@ -6,6 +6,23 @@ Here is a sample of JSON output when nothing is detected:
         "detections": []
     }
 
+Here is a sample of JSON output when the filters are **on**:
+
+    {
+        "video-rate": 25.0, 
+        "drpai-rate": 5.4, 
+        "filter-classes": [
+            "bottle"
+        ], 
+        "filter-region": {
+            "left": 450, 
+            "top": 350, 
+            "width": 100, 
+            "height": 100
+        }, 
+        "detections": []
+    }
+
 Here is a sample of JSON output of Yolo models when the tracking is **off**:
 
     {

--- a/gst-plugin/src/box.cpp
+++ b/gst-plugin/src/box.cpp
@@ -28,26 +28,6 @@
 #include "box.h"
 
 /*****************************************
-* Function Name : overlap
-* Description   : Function to compute the overlapped data between coordinate x with size w
-* Arguments     : x1 = 1-dimensional coordinate of first line
-*                 w1 = size of fist line
-*                 x2 = 1-dimensional coordinate of second line
-*                 w2 = size of second line
-* Return value  : overlapped line size
-******************************************/
-float Box::overlap(const float x1, const float w1, const float x2, const float w2)
-{
-    const float l1 = x1 - w1/2;
-    const float l2 = x2 - w2/2;
-    const float left = l1 > l2 ? l1 : l2;
-    const float r1 = x1 + w1/2;
-    const float r2 = x2 + w2/2;
-    const float right = r1 < r2 ? r1 : r2;
-    return right - left;
-}
-
-/*****************************************
 * Function Name : box_intersection
 * Description   : Function to compute the area of intersection of Box a and b
 * Arguments     : a = Box 1
@@ -56,8 +36,8 @@ float Box::overlap(const float x1, const float w1, const float x2, const float w
 ******************************************/
 float Box::operator&(const Box& b) const
 {
-    const float _w = overlap(x, w, b.x, b.w);
-    const float _h = overlap(y, h, b.y, b.h);
+    const float _w = std::min(getRight(), b.getRight()) - std::max(getLeft(), b.getLeft());
+    const float _h = std::min(getBottom(), b.getBottom()) - std::max(getTop(), b.getTop());
     if(_w < 0 || _h < 0)
     {
         return 0;

--- a/gst-plugin/src/box.cpp
+++ b/gst-plugin/src/box.cpp
@@ -99,6 +99,20 @@ float Box::doa_with(const Box& b) const
     return static_cast<float>(distance/avg_area);
 }
 
+json_object Box::get_json(bool center_origin) const {
+    json_object j;
+    if (center_origin) {
+        j.add("centerX", x, 0);
+        j.add("centerY", y, 0);
+    } else {
+        j.add("left", getLeft(), 0);
+        j.add("top", getTop(), 0);
+    }
+    j.add("width", w, 0);
+    j.add("height", h, 0);
+    return j;
+}
+
 /*****************************************
 * Function Name : filter_boxes_nms
 * Description   : Apply Non-Maximum Suppression (NMS) to get rid of overlapped rectangles.

--- a/gst-plugin/src/box.h
+++ b/gst-plugin/src/box.h
@@ -37,31 +37,29 @@ typedef struct Box
 {
     float x, y, w, h;
 
-    [[nodiscard]] json_object get_json() const {
-        json_object j;
-        j.add("centerX", x, 0);
-        j.add("centerY", y, 0);
-        j.add("width", w, 0);
-        j.add("height", h, 0);
-        return j;
-    }
+    inline void setLeft(const float _x) { x = _x + w/2; }
+    inline void setTop(const float _y) { y = _y + h/2; }
+
+    [[nodiscard]] inline float getLeft() const { return x - w/2; }
+    [[nodiscard]] inline float getTop() const { return y - h/2; }
+    [[nodiscard]] json_object get_json(bool center_origin=true) const;
 
     [[nodiscard]] static float overlap(float x1, float w1, float x2, float w2);
     [[nodiscard]] float iou_with(const Box& b) const;
     [[nodiscard]] float doa_with(const Box& b) const;
-    [[nodiscard]] float area() const { return w*h; };
+    [[nodiscard]] float inline area() const { return w*h; };
 
     [[nodiscard]] float operator&(const Box& b) const; // intersection
     [[nodiscard]] float operator|(const Box& b) const; // union
-    [[nodiscard]] float operator%(const Box& b) const { // euclidean distance
+    [[nodiscard]] float inline operator%(const Box& b) const { // euclidean distance
         const auto dx = x - b.x;
         const auto dy = y - b.y;
         return std::sqrt(dx*dx + dy*dy);
     }
-    [[nodiscard]] Box operator*(const float a) const { return Box {x*a, y*a, w*a, h*a}; }
-    [[nodiscard]] Box operator/(const float a) const { return Box {x/a, y/a, w/a, h/a}; }
-    [[nodiscard]] Box operator+(const Box& a) const { return Box {x+a.x, y+a.y, w+a.w, h+a.h}; }
-    [[nodiscard]] Box average_with(const float my_weight, const float other_weight, const Box& other) const {
+    [[nodiscard]] Box inline operator*(const float a) const { return Box {x*a, y*a, w*a, h*a}; }
+    [[nodiscard]] Box inline operator/(const float a) const { return Box {x/a, y/a, w/a, h/a}; }
+    [[nodiscard]] Box inline operator+(const Box& a) const { return Box {x+a.x, y+a.y, w+a.w, h+a.h}; }
+    [[nodiscard]] Box inline average_with(const float my_weight, const float other_weight, const Box& other) const {
         return (operator*(my_weight) + other*other_weight) / (my_weight+other_weight);
     }
 } Box;
@@ -86,7 +84,7 @@ typedef struct detection
         json_object j;
         j.add("class", name);
         j.add("probability", prob, 2);
-        j.add("box", bbox.get_json());
+        j.add("box", bbox.get_json(true));
         return j;
     }
 } detection;

--- a/gst-plugin/src/box.h
+++ b/gst-plugin/src/box.h
@@ -42,9 +42,10 @@ typedef struct Box
 
     [[nodiscard]] inline float getLeft() const { return x - w/2; }
     [[nodiscard]] inline float getTop() const { return y - h/2; }
+    [[nodiscard]] inline float getRight() const { return x + w/2; }
+    [[nodiscard]] inline float getBottom() const { return y + h/2; }
     [[nodiscard]] json_object get_json(bool center_origin=true) const;
 
-    [[nodiscard]] static float overlap(float x1, float w1, float x2, float w2);
     [[nodiscard]] float iou_with(const Box& b) const;
     [[nodiscard]] float doa_with(const Box& b) const;
     [[nodiscard]] float inline area() const { return w*h; };

--- a/gst-plugin/src/drpai-models/drpai_connection.cpp
+++ b/gst-plugin/src/drpai-models/drpai_connection.cpp
@@ -471,11 +471,11 @@ void DRPAI_Connection::crop(const Box& crop_region) const {
         throw std::runtime_error("[ERROR] Failed to DRPAI prepost crop:  errno=" + std::to_string(errno) + " " + std::string(std::strerror(errno)));
 }
 
-void DRPAI_Connection::render_filter_region(Image &img) {
+void DRPAI_Connection::render_filter_region(Image &img) const {
     if (filter_region.area() > 0)
-        img.draw_rect(static_cast<int32_t>(filter_region.x),
-                      static_cast<int32_t>(filter_region.y),
-                      static_cast<int32_t>(filter_region.x + filter_region.w),
-                      static_cast<int32_t>(filter_region.y + filter_region.h),
+        img.draw_rect(static_cast<int32_t>(filter_region.getLeft()),
+                      static_cast<int32_t>(filter_region.getTop()),
+                      static_cast<int32_t>(filter_region.getRight()),
+                      static_cast<int32_t>(filter_region.getBottom()),
                       YELLOW_DATA, 0);
 }

--- a/gst-plugin/src/drpai-models/drpai_connection.cpp
+++ b/gst-plugin/src/drpai-models/drpai_connection.cpp
@@ -386,7 +386,7 @@ json_object DRPAI_Connection::get_json() const {
     j.add("drpai-rate", rate.get_smooth_rate(), 1);
     if (!filter_classes.empty())
         j.add("filter-classes", json_array(filter_classes));
-    if (filter_region.area() > 0)
+    if (filter_region.area() < 640*480)
         j.add("filter-region", filter_region.get_json(false));
     j.add("detections", get_detections_json());
     return j;
@@ -472,7 +472,7 @@ void DRPAI_Connection::crop(const Box& crop_region) const {
 }
 
 void DRPAI_Connection::render_filter_region(Image &img) const {
-    if (filter_region.area() > 0)
+    if (filter_region.area() < 640*480)
         img.draw_rect(static_cast<int32_t>(filter_region.getLeft()),
                       static_cast<int32_t>(filter_region.getTop()),
                       static_cast<int32_t>(filter_region.getRight()),

--- a/gst-plugin/src/drpai-models/drpai_connection.h
+++ b/gst-plugin/src/drpai-models/drpai_connection.h
@@ -41,8 +41,13 @@ public:
     fps rate {};
     std::string prefix {};
     std::vector<detection> last_det {};
-    Box filter_region {};
     std::vector<std::string> corner_text {};
+
+    /* Filter section */
+    bool show_filter = false;
+    Box filter_region {};
+    std::vector<std::string> filter_classes {};
+    void render_filter_region(Image& img);
 
     /*DRP-AI Input image information*/
     int32_t IN_WIDTH = 0;

--- a/gst-plugin/src/drpai-models/drpai_connection.h
+++ b/gst-plugin/src/drpai-models/drpai_connection.h
@@ -47,7 +47,7 @@ public:
     bool show_filter = false;
     Box filter_region {};
     std::vector<std::string> filter_classes {};
-    void render_filter_region(Image& img);
+    void render_filter_region(Image& img) const;
 
     /*DRP-AI Input image information*/
     int32_t IN_WIDTH = 0;

--- a/gst-plugin/src/drpai-models/drpai_yolo.cpp
+++ b/gst-plugin/src/drpai-models/drpai_yolo.cpp
@@ -94,7 +94,7 @@ void DRPAI_Yolo::open_resource(const uint32_t data_in_address) {
         std::cout << "Option : Detection Tracking is Active!" << std::endl;
     if (!filter_classes.empty())
         std::cout << "Option : Filtering classes to " << json_array(filter_classes).to_string() << std::endl;
-    if (filter_region.area() > 0)
+    if (filter_region.area() < 640*480)
         std::cout << "Option : Filtering region of interest to " << filter_region.get_json(false).to_string() << std::endl;
 }
 

--- a/gst-plugin/src/drpai-models/drpai_yolo.cpp
+++ b/gst-plugin/src/drpai-models/drpai_yolo.cpp
@@ -58,7 +58,7 @@ void DRPAI_Yolo::extract_detections()
         if (det[i].prob == 0) continue;
 
         /* Skip the bounding boxes outside of region of interest */
-        if (!filter_classes.empty() && in(det[i].name, filter_classes)) continue;
+        if (!(filter_classes.empty() || in(det[i].name, filter_classes))) continue;
         if ((filter_region & det[i].bbox) == 0) continue;
 
         last_det.push_back(det[i]);
@@ -91,11 +91,11 @@ void DRPAI_Yolo::open_resource(const uint32_t data_in_address) {
     std::cout << "Model : Darknet YOLO      | " << prefix << std::endl;
     DRPAI_Connection::open_resource(data_in_address);
     if (det_tracker.active)
-        std::cout << "Option: Detection Tracking is Active!" << std::endl;
+        std::cout << "Option : Detection Tracking is Active!" << std::endl;
     if (!filter_classes.empty())
-        std::cout << "Option: Filtering classes to " << json_array(filter_classes).to_string() << std::endl;
+        std::cout << "Option : Filtering classes to " << json_array(filter_classes).to_string() << std::endl;
     if (filter_region.area() > 0)
-        std::cout << "Option: Filtering region of interest to " << filter_region.get_json(false).to_string() << std::endl;
+        std::cout << "Option : Filtering region of interest to " << filter_region.get_json(false).to_string() << std::endl;
 }
 
 void DRPAI_Yolo::render_detections_on_image(Image &img) {

--- a/gst-plugin/src/drpai-models/drpai_yolo.cpp
+++ b/gst-plugin/src/drpai-models/drpai_yolo.cpp
@@ -99,7 +99,7 @@ void DRPAI_Yolo::render_detections_on_image(Image &img) {
         for (const auto& tracked: last_tracked_detection)
         {
             /* Draw the bounding box on the image */
-            img.draw_rect(tracked->last_detection.bbox, tracked->to_string_hr());
+            img.draw_rect(tracked->last_detection.bbox, tracked->to_string_hr(), RED_DATA, BLACK_DATA);
         }
     else
         DRPAI_Connection::render_detections_on_image(img);

--- a/gst-plugin/src/drpai-models/drpai_yolo.cpp
+++ b/gst-plugin/src/drpai-models/drpai_yolo.cpp
@@ -92,6 +92,10 @@ void DRPAI_Yolo::open_resource(const uint32_t data_in_address) {
     DRPAI_Connection::open_resource(data_in_address);
     if (det_tracker.active)
         std::cout << "Option: Detection Tracking is Active!" << std::endl;
+    if (!filter_classes.empty())
+        std::cout << "Option: Filtering classes to " << json_array(filter_classes).to_string() << std::endl;
+    if (filter_region.area() > 0)
+        std::cout << "Option: Filtering region of interest to " << filter_region.get_json(false).to_string() << std::endl;
 }
 
 void DRPAI_Yolo::render_detections_on_image(Image &img) {

--- a/gst-plugin/src/drpai-models/drpai_yolo.h
+++ b/gst-plugin/src/drpai-models/drpai_yolo.h
@@ -18,7 +18,6 @@ public:
 
     bool log_detects = false;
     tracker det_tracker;
-    std::vector<std::string> filter_classes {};
 
     void open_resource(uint32_t data_in_address) override;
     void extract_detections() override;

--- a/gst-plugin/src/drpai_controller.cpp
+++ b/gst-plugin/src/drpai_controller.cpp
@@ -95,6 +95,8 @@ void DRPAI_Controller::process_image(uint8_t* img_data) {
         drpai.corner_text.push_back("Video Rate: " + std::to_string(static_cast<int32_t>(video_rate.get_smooth_rate())) + " fps");
         drpai.add_corner_text();
     }
+    if (drpai.show_filter)
+        drpai.render_filter_region(img);
     drpai.render_detections_on_image(img);
     drpai.render_text_on_image(img);
 

--- a/gst-plugin/src/gstdrpai.cpp
+++ b/gst-plugin/src/gstdrpai.cpp
@@ -99,6 +99,7 @@ enum {
     PROP_FILTER_TOP,
     PROP_FILTER_WIDTH,
     PROP_FILTER_HEIGHT,
+    PROP_FILTER_SHOW,
 };
 
 /* the capabilities of the inputs and outputs.
@@ -216,6 +217,10 @@ gst_drpai_class_init(GstDRPAIClass *klass) {
         g_param_spec_uint("filter_height", "Filter Height",
                           "The height of the region of interest to filter the detection.",
                           1, CAP_HEIGHT, CAP_HEIGHT, G_PARAM_READWRITE));
+    g_object_class_install_property(gobject_class, PROP_FILTER_SHOW,
+        g_param_spec_boolean("filter_show", "Filter Show",
+                             "Show a yellow box where the filter is applied.",
+                             FALSE, G_PARAM_READWRITE));
 
     gst_element_class_set_details_simple(gstelement_class,
                                          "DRP-AI",
@@ -350,16 +355,21 @@ gst_drpai_set_property(GObject *object, const guint prop_id,
             break;
         }
         case PROP_FILTER_LEFT:
-            obj->drpai_controller->drpai.filter_region.x = static_cast<float>(g_value_get_uint(value));
+            obj->drpai_controller->drpai.filter_region.setLeft(static_cast<float>(g_value_get_uint(value)));
             break;
         case PROP_FILTER_TOP:
-            obj->drpai_controller->drpai.filter_region.y = static_cast<float>(g_value_get_uint(value));
+            obj->drpai_controller->drpai.filter_region.setTop(static_cast<float>(g_value_get_uint(value)));
             break;
         case PROP_FILTER_WIDTH:
             obj->drpai_controller->drpai.filter_region.w = static_cast<float>(g_value_get_uint(value));
+            obj->drpai_controller->drpai.filter_region.setLeft(obj->drpai_controller->drpai.filter_region.x);
             break;
         case PROP_FILTER_HEIGHT:
             obj->drpai_controller->drpai.filter_region.h = static_cast<float>(g_value_get_uint(value));
+            obj->drpai_controller->drpai.filter_region.setTop(obj->drpai_controller->drpai.filter_region.y);
+            break;
+        case PROP_FILTER_SHOW:
+            obj->drpai_controller->drpai.show_filter = g_value_get_boolean(value);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -423,16 +433,19 @@ gst_drpai_get_property(GObject *object, const guint prop_id,
             break;
         }
         case PROP_FILTER_LEFT:
-            g_value_set_uint(value, static_cast<uint>(obj->drpai_controller->drpai.filter_region.x));
+            g_value_set_uint(value, static_cast<uint>(obj->drpai_controller->drpai.filter_region.getLeft()));
             break;
         case PROP_FILTER_TOP:
-            g_value_set_uint(value, static_cast<uint>(obj->drpai_controller->drpai.filter_region.y));
+            g_value_set_uint(value, static_cast<uint>(obj->drpai_controller->drpai.filter_region.getTop()));
             break;
         case PROP_FILTER_WIDTH:
             g_value_set_uint(value, static_cast<uint>(obj->drpai_controller->drpai.filter_region.w));
             break;
         case PROP_FILTER_HEIGHT:
             g_value_set_uint(value, static_cast<uint>(obj->drpai_controller->drpai.filter_region.h));
+            break;
+        case PROP_FILTER_SHOW:
+            g_value_set_boolean(value, obj->drpai_controller->drpai.show_filter);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);

--- a/gst-plugin/src/gstdrpai.cpp
+++ b/gst-plugin/src/gstdrpai.cpp
@@ -352,13 +352,13 @@ gst_drpai_set_property(GObject *object, const guint prop_id,
             obj->drpai_controller->drpai.det_tracker.history_length = g_value_get_float(value);
             break;
         case PROP_FILTER_CLASS: {
-            const std::string csv_classes = g_value_get_string(value);
+            std::stringstream csv_classes(g_value_get_string(value));
             obj->drpai_controller->drpai.filter_classes.clear();
-            if (!csv_classes.empty()) {
-                std::stringstream ss(csv_classes);
+            while (csv_classes.good()) {
                 std::string item;
-                while (std::getline(ss, item, ','))
-                    obj->drpai_controller->drpai.filter_classes.push_back(std::move(item));
+                std::getline(csv_classes, item, ',');
+                if(!item.empty())
+                    obj->drpai_controller->drpai.filter_classes.push_back(item);
             }
             break;
         }

--- a/gst-plugin/src/image.cpp
+++ b/gst-plugin/src/image.cpp
@@ -99,7 +99,7 @@ void Image::copy(const uint8_t* data, IMAGE_FORMAT f) {
 *                 backcolor = character background color
 * Return value  : -
 ******************************************/
-void Image::write_char(const char code, const int32_t x, const int32_t y, const int32_t color, const int32_t backcolor) const
+void Image::write_char(const char code, const int32_t x, const int32_t y, const uint32_t color, const uint32_t backcolor) const
 {
     // Pick the pattern related to the ASCII code from the elements of the g_ascii_table array.
     // The array doesn't include the non-printable characters, so we need to shift the code to match the element.
@@ -138,7 +138,7 @@ void Image::write_char(const char code, const int32_t x, const int32_t y, const 
 * Return Value  : -
 ******************************************/
 void Image::write_string(const std::string& pcode, int32_t x,  int32_t y,
-                         const int32_t color, const int32_t backcolor, int8_t margin) const
+                         const uint32_t color, const uint32_t backcolor, int8_t margin) const
 {
     const auto str_size = static_cast<int32_t>(pcode.size());
     if (str_size == 0) return;
@@ -187,7 +187,7 @@ void Image::draw_point(const uint32_t x, const uint32_t y, const uint32_t color)
 *                 color = line color
 * Return Value  : -
 ******************************************/
-void Image::draw_line(int32_t x0, int32_t y0, const int32_t x1, const int32_t y1, const int32_t color) const
+void Image::draw_line(int32_t x0, int32_t y0, const int32_t x1, const int32_t y1, const uint32_t color) const
 {
     auto dx = static_cast<float>(x1 - x0);
     auto dy = static_cast<float>(y1 - y0);
@@ -253,7 +253,7 @@ void Image::draw_line(int32_t x0, int32_t y0, const int32_t x1, const int32_t y1
 *                 str = string to label the rectangle
 * Return Value  : -
 ******************************************/
-void Image::draw_rect(const Box& box, const std::string& str) const
+void Image::draw_rect(const Box& box, const std::string& str, const uint32_t front_color, const uint32_t back_color) const
 {
     auto x_min = static_cast<int32_t>(box.x - round(box.w / 2.));
     auto y_min = static_cast<int32_t>(box.y - round(box.h / 2.));
@@ -268,14 +268,16 @@ void Image::draw_rect(const Box& box, const std::string& str) const
     /* Draw the class and probability */
     write_string(str, x_min + 1, y_min + 1, back_color,  front_color, 5);
     /* Draw the bounding box */
-    draw_line(x_min, y_min, x_max, y_min, front_color);
-    draw_line(x_max, y_min, x_max, y_max, front_color);
-    draw_line(x_max, y_max, x_min, y_max, front_color);
-    draw_line(x_min, y_max, x_min, y_min, front_color);
-    draw_line(x_min-1, y_min-1, x_max+1, y_min-1, back_color);
-    draw_line(x_max+1, y_min-1, x_max+1, y_max+1, back_color);
-    draw_line(x_max+1, y_max+1, x_min-1, y_max+1, back_color);
-    draw_line(x_min-1, y_max+1, x_min-1, y_min-1, back_color);
+    draw_rect(x_min, y_min, x_max, y_max, front_color, 0);
+    draw_rect(x_min, y_min, x_max, y_max, back_color, 1);
+}
+
+void Image::draw_rect(const int32_t x_min, const int32_t y_min, const int32_t x_max, const int32_t y_max,
+                      const uint32_t color, const int32_t expand) const {
+    draw_line(x_min - expand, y_min - expand, x_max + expand, y_min - expand, color);
+    draw_line(x_max + expand, y_min - expand, x_max + expand, y_max + expand, color);
+    draw_line(x_max + expand, y_max + expand, x_min - expand, y_max + expand, color);
+    draw_line(x_min - expand, y_max + expand, x_min - expand, y_min - expand, color);
 }
 
 /*****************************************

--- a/gst-plugin/src/image.h
+++ b/gst-plugin/src/image.h
@@ -28,9 +28,12 @@
 #include <memory>
 #include "box.h"
 
-constexpr uint32_t RED_DATA   = 0x0000FFu;
-constexpr uint32_t WHITE_DATA = 0xFFFFFFu;
 constexpr uint32_t BLACK_DATA = 0x000000u;
+constexpr uint32_t RED_DATA   = 0x0000FFu;
+constexpr uint32_t GREEN_DATA = RED_DATA << 8;
+constexpr uint32_t BLUE_DATA  = GREEN_DATA << 8;
+constexpr uint32_t YELLOW_DATA= RED_DATA | GREEN_DATA;
+constexpr uint32_t WHITE_DATA = RED_DATA | GREEN_DATA | BLUE_DATA;
 enum IMAGE_FORMAT {
     BGR_DATA, YUV_DATA
 };
@@ -49,9 +52,10 @@ class Image
         void map_udmabuf();
         void copy(const uint8_t* data, IMAGE_FORMAT format);
         void prepare();
-        void draw_rect(const Box& box, const std::string& str) const;
+        void draw_rect(const Box& box, const std::string& str, uint32_t front_color, uint32_t back_color) const;
+        void draw_rect(int32_t x_min, int32_t y_min, int32_t x_max, int32_t y_max, uint32_t color, int32_t expand) const;
         void write_string(const std::string& pcode, int32_t x,  int32_t y,
-                          int32_t color, int32_t backcolor, int8_t margin=0) const;
+                          uint32_t color, uint32_t backcolor, int8_t margin=0) const;
 
     private:
         uint8_t udmabuf_fd = 0;
@@ -70,13 +74,11 @@ class Image
         void copy_convert_bgr_to_yuy2() const;
 
         /* drawing section */
-        constexpr static uint32_t front_color = RED_DATA;
-        constexpr static uint32_t back_color = BLACK_DATA;
         constexpr static int32_t font_w = 6;
         constexpr static int32_t font_h = 8;
         void draw_point(uint32_t x, uint32_t y, uint32_t color) const;
-        void draw_line(int32_t x0, int32_t y0, int32_t x1, int32_t y1, int32_t color) const;
-        void write_char(char code, int32_t x, int32_t y, int32_t color, int32_t backcolor) const;
+        void draw_line(int32_t x0, int32_t y0, int32_t x1, int32_t y1, uint32_t color) const;
+        void write_char(char code, int32_t x, int32_t y, uint32_t color, uint32_t backcolor) const;
 };
 
 #endif

--- a/gst-plugin/src/json.h
+++ b/gst-plugin/src/json.h
@@ -7,6 +7,7 @@
 
 #include <iomanip>
 #include <sstream>
+#include <vector>
 
 class json_base {
 
@@ -57,6 +58,9 @@ private:
 
 class json_array final: public json_base {
 public:
+    json_array() = default;
+    explicit json_array(const std::vector<std::string>& array) { for(auto& a: array) add(a); }
+
     void add(const float value, const int precision) override { add_comma(); json_base::add(value, precision); }
     void add(const int value) override { add_comma(); json_base::add(value); }
     void add(const unsigned int value) override { add_comma(); json_base::add(value); }


### PR DESCRIPTION
In this pull request, I am adding the feature to draw a yellow box to show the filtered region of interest.

While implementing this, I noticed geometric issues with the previous implementation so I fixed them.

I am also adding the filter information to the JSON output. See `JSON.md`.


https://github.com/MistySOM/gstreamer1.0-drpai/assets/7337168/43ad8ebb-6e04-4477-ba4b-b904ce20073c

