### PR TITLE
Subtract height from bbox labels

### DIFF
--- a/gst-plugin/src/image.cpp
+++ b/gst-plugin/src/image.cpp
@@ -266,7 +266,9 @@ void Image::draw_rect(const Box& box, const std::string& str, const uint32_t fro
     y_max = std::min(y_max, img_h -2);
 
     /* Draw the class and probability */
-    write_string(str, x_min + 1, y_min + 1, back_color,  front_color, 5);
+    const auto margin = 5;
+    const auto str_height = font_h + 2*margin;
+    write_string(str, x_min + 1, y_min + 1 - str_height, back_color,  front_color, margin);
     /* Draw the bounding box */
     draw_rect(x_min, y_min, x_max, y_max, front_color, 0);
     draw_rect(x_min, y_min, x_max, y_max, back_color, 1);


### PR DESCRIPTION
This pull request fixes #28 

See the screenshot
![image](https://github.com/MistySOM/gstreamer1.0-drpai/assets/7337168/3e689120-9a63-4414-8ecf-2d02f67c7b2f)
