### PR TITLE
Add property for show track ID + change history time from float to int

### DIFF
--- a/gst-plugin/src/drpai-models/drpai_yolo.cpp
+++ b/gst-plugin/src/drpai-models/drpai_yolo.cpp
@@ -72,7 +72,7 @@ void DRPAI_Yolo::extract_detections()
             for (const auto& detection: last_tracked_detection) {
                 /* Print the box details on console */
                 //print_box(detection, n++);
-                std::cout << detection->to_string_hr() + "\t";
+                std::cout << detection->to_string_hr(true) + "\t";
             }
         }
         else {
@@ -103,7 +103,7 @@ void DRPAI_Yolo::render_detections_on_image(Image &img) {
         for (const auto& tracked: last_tracked_detection)
         {
             /* Draw the bounding box on the image */
-            img.draw_rect(tracked->last_detection.bbox, tracked->to_string_hr(), RED_DATA, BLACK_DATA);
+            img.draw_rect(tracked->last_detection.bbox, tracked->to_string_hr(show_track_id), RED_DATA, BLACK_DATA);
         }
     else
         DRPAI_Connection::render_detections_on_image(img);

--- a/gst-plugin/src/drpai-models/drpai_yolo.h
+++ b/gst-plugin/src/drpai-models/drpai_yolo.h
@@ -16,6 +16,7 @@ public:
             det_tracker(true, 2, 2.25, 1)
     {}
 
+    bool show_track_id = false;
     tracker det_tracker;
 
     void open_resource(uint32_t data_in_address) override;

--- a/gst-plugin/src/gstdrpai.cpp
+++ b/gst-plugin/src/gstdrpai.cpp
@@ -91,6 +91,7 @@ enum {
     PROP_SMOOTH_DRPAI_RATE,
     PROP_SMOOTH_BBOX_RATE,
 
+    PROP_TRACK_SHOW_ID,
     PROP_TRACK_SECONDS,
     PROP_TRACK_DOA_THRESHOLD,
     PROP_TRACK_HISTORY_LENGTH,
@@ -190,6 +191,10 @@ gst_drpai_class_init(GstDRPAIClass *klass) {
         g_param_spec_uint("smooth_bbox_rate", "Smooth Bounding Box Framerate",
                           "Number of last bounding-box updates to average. (requires tracking)",
                           1, 1000, 1, G_PARAM_READWRITE));
+    g_object_class_install_property(gobject_class, PROP_TRACK_SHOW_ID,
+        g_param_spec_boolean("show_track_id", "Show Track ID",
+                             "Show the track ID on the detection labels.",
+                             FALSE, G_PARAM_READWRITE));
     g_object_class_install_property(gobject_class, PROP_TRACK_SECONDS,
         g_param_spec_float("track_seconds", "Track Seconds",
                            "Number of seconds to wait for a tracked undetected object to forget it.",
@@ -199,9 +204,9 @@ gst_drpai_class_init(GstDRPAIClass *klass) {
                            "The threshold of Distance Over Areas (DOA) for tracking bounding-boxes.",
                            0.001, 1000, 2.25, G_PARAM_READWRITE));
     g_object_class_install_property(gobject_class, PROP_TRACK_HISTORY_LENGTH,
-        g_param_spec_float("track_history_length", "Track History Length",
-                           "Minutes to keep the tracking history.",
-                           0, 1440, 60, G_PARAM_READWRITE));
+        g_param_spec_int("track_history_length", "Track History Length",
+                         "Minutes to keep the tracking history.",
+                         0, 1440, 60, G_PARAM_READWRITE));
     g_object_class_install_property(gobject_class, PROP_FILTER_CLASS,
         g_param_spec_string("filter_class", "Filter Class",
                             "A comma-separated list of classes to filter the detection.",
@@ -342,6 +347,9 @@ gst_drpai_set_property(GObject *object, const guint prop_id,
         case PROP_SMOOTH_BBOX_RATE:
             obj->drpai_controller->drpai.det_tracker.bbox_smooth_rate = g_value_get_uint(value);
             break;
+        case PROP_TRACK_SHOW_ID:
+            obj->drpai_controller->drpai.show_track_id = g_value_get_boolean(value);
+            break;
         case PROP_TRACK_SECONDS:
             obj->drpai_controller->drpai.det_tracker.time_threshold = g_value_get_float(value);
             break;
@@ -349,7 +357,7 @@ gst_drpai_set_property(GObject *object, const guint prop_id,
             obj->drpai_controller->drpai.det_tracker.doa_threshold = g_value_get_float(value);
             break;
         case PROP_TRACK_HISTORY_LENGTH:
-            obj->drpai_controller->drpai.det_tracker.history_length = g_value_get_float(value);
+            obj->drpai_controller->drpai.det_tracker.history_length = g_value_get_int(value);
             break;
         case PROP_FILTER_CLASS: {
             std::stringstream csv_classes(g_value_get_string(value));
@@ -424,6 +432,9 @@ gst_drpai_get_property(GObject *object, const guint prop_id,
         case PROP_SMOOTH_BBOX_RATE:
             g_value_set_uint(value, obj->drpai_controller->drpai.det_tracker.bbox_smooth_rate);
             break;
+        case PROP_TRACK_SHOW_ID:
+            g_value_set_boolean(value, obj->drpai_controller->drpai.show_track_id);
+            break;
         case PROP_TRACK_SECONDS:
             g_value_set_float(value, obj->drpai_controller->drpai.det_tracker.time_threshold);
             break;
@@ -431,7 +442,7 @@ gst_drpai_get_property(GObject *object, const guint prop_id,
             g_value_set_float(value, obj->drpai_controller->drpai.det_tracker.doa_threshold);
             break;
         case PROP_TRACK_HISTORY_LENGTH:
-            g_value_set_float(value, obj->drpai_controller->drpai.det_tracker.history_length);
+            g_value_set_int(value, obj->drpai_controller->drpai.det_tracker.history_length);
             break;
         case PROP_FILTER_CLASS: {
             std::string ss;

--- a/gst-plugin/src/tracker.h
+++ b/gst-plugin/src/tracker.h
@@ -24,8 +24,10 @@ struct tracked_detection {
     tracked_detection(const uint32_t id, const detection& det, const tracking_time& time):
             id(id), smoothed(1), last_detection(det), seen_first(time), seen_last(time) {}
 
-    [[nodiscard]] std::string to_string_hr() const {
-        return std::to_string(id) + "." + last_detection.to_string_hr();
+    [[nodiscard]] std::string to_string_hr(bool include_id) const {
+        if(include_id)
+            return std::to_string(id) + "." + last_detection.to_string_hr();
+        return last_detection.to_string_hr();
     }
     [[nodiscard]] json_object get_json() const;
 


### PR DESCRIPTION
In this pull request I added another property so one can enable or disable the ID in detection names. It is named `show-track-id`. If not set, it defaults to `false`. 

I will edit the wiki later.

Here is an example of the command:

````
gst-launch-1.0 v4l2src device=/dev/video0 \
    ! drpai model=yolov3 \
        show-fps=true \
        show-track-id=true \
        track-seconds=1 \
        track-doa-thresh=25 \
        smooth-video-rate=30 \
        smooth-bbox-rate=2 \
    ! vspmfilter dmabuf-use=true ! video/x-raw, format=NV12 \
    ! omxh264enc control-rate=2 target-bitrate=10485760 interval_intraframes=14 periodicty-idr=2 \
    ! video/x-h264,profile=\(string\)high,level=\(string\)4.2 \
    ! rtph264pay config-interval=-1 ! udpsink host=192.168.100.41 port=51372
````