### PR TITLE
Add thread name for easier debugging

### DIFF
--- a/gst-plugin/src/drpai_controller.cpp
+++ b/gst-plugin/src/drpai_controller.cpp
@@ -155,6 +155,7 @@ void DRPAI_Controller::release_resources() {
 
 void DRPAI_Controller::thread_function_loop() {
     try {
+        pthread_setname_np(pthread_self(), "drpai_thread");
         while (true) {
             thread_function_single();
         }


### PR DESCRIPTION
In this pull request, I added a name to the thread I use for the DRPAI process and post-process.

It helps me in gdb