### PR TITLE
Add timestamp to JSON and change format

### DIFF
--- a/JSON.md
+++ b/JSON.md
@@ -1,14 +1,19 @@
 Here is a sample of JSON output when nothing is detected:
 
+```json
     {
+        "timestamp": "2024-02-12T16:03:45.484Z",
         "video-rate": 33.3, 
         "drpai-rate": 2.5, 
         "detections": []
     }
+```
 
 Here is a sample of JSON output when the filters are **on**:
 
+```json
     {
+        "timestamp": "2024-02-12T16:03:45.484Z",
         "video-rate": 25.0, 
         "drpai-rate": 5.4, 
         "filter-classes": [
@@ -22,10 +27,13 @@ Here is a sample of JSON output when the filters are **on**:
         }, 
         "detections": []
     }
+```
 
 Here is a sample of JSON output of Yolo models when the tracking is **off**:
 
+```json
     {
+        "timestamp": "2024-02-12T16:03:45.484Z",
         "video-rate": 32.3, 
         "drpai-rate": 2.5, 
         "detections": [
@@ -51,17 +59,20 @@ Here is a sample of JSON output of Yolo models when the tracking is **off**:
             }
         ]
     }
+```
 
 Here is a sample of JSON output of Yolo models when the tracking is **on**:
 
+```json
     {
+        "timestamp": "2024-02-12T16:03:45.484Z",
         "video-rate": 32.3, 
         "drpai-rate": 2.5, 
         "detections": [
             {
                 "id": 2, 
-                "seen_first": "Fri Dec 22 23:20:56 2023", 
-                "seen_last": "Fri Dec 22 23:21:46 2023", 
+                "seen_first": "2023-12-22T23:20:56.484Z", 
+                "seen_last": "2023-12-22T23:21:46.484Z", 
                 "class": "person", 
                 "probability": 0.91, 
                 "box": {
@@ -73,8 +84,8 @@ Here is a sample of JSON output of Yolo models when the tracking is **on**:
             },
             {
                 "id": 5, 
-                "seen_first": "Fri Dec 22 23:25:53 2023", 
-                "seen_last": "Fri Dec 22 23:26:07 2023", 
+                "seen_first": "2023-12-22T23:25:53.484Z", 
+                "seen_last": "2023-12-22T23:26:07.484Z", 
                 "class": "wine glass", 
                 "probability": 0.52, 
                 "box": {
@@ -93,3 +104,4 @@ Here is a sample of JSON output of Yolo models when the tracking is **on**:
             "chair": 1
         }
     }
+```

--- a/gst-plugin/src/drpai_controller.cpp
+++ b/gst-plugin/src/drpai_controller.cpp
@@ -196,6 +196,7 @@ void DRPAI_Controller::thread_function_single() {
 
     if(socket_fd) {
         json_object j;
+        j.add("timestamp", elapsed_time::to_string(std::chrono::system_clock::now()));
         j.add("video-rate", video_rate.get_smooth_rate(), 1);
         j.concatenate(drpai->get_json());
         const auto str = j.to_string() + "\n";

--- a/gst-plugin/src/tracker.cpp
+++ b/gst-plugin/src/tracker.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "tracker.h"
+#include "utils/elapsed_time.h"
 
 inline double get_duration_seconds(const tracking_time &a, const tracking_time &b) {
     return std::chrono::duration<double>(a - b).count();
@@ -11,18 +12,11 @@ inline long get_duration_minutes(const tracking_time &a, const tracking_time &b)
     return std::chrono::duration_cast<std::chrono::minutes>(a - b).count();
 }
 
-std::string tracked_detection::to_string(const tracking_time& time) {
-    const std::time_t t = std::chrono::system_clock::to_time_t(time);
-    std::string ts = std::ctime(&t);
-    ts.resize(ts.size()-1);
-    return ts;
-}
-
 json_object tracked_detection::get_json() const {
     json_object j;
     j.add("id", id);
-    j.add("seen-first", to_string(seen_first));
-    j.add("seen-last", to_string(seen_last));
+    j.add("seen-first", elapsed_time::to_string(seen_first));
+    j.add("seen-last", elapsed_time::to_string(seen_last));
     j.add("class", std::string(name));
     j.add("probability", prob, 2);
     j.add("box", smooth_bbox.mix.get_json(true));

--- a/gst-plugin/src/tracker.h
+++ b/gst-plugin/src/tracker.h
@@ -44,9 +44,6 @@ struct tracked_detection {
         return r;
     }
     [[nodiscard]] json_object get_json() const;
-
-private:
-    [[nodiscard]] static std::string to_string(const tracking_time& time);
 };
 using tracked_detection_vector = std::vector<std::shared_ptr<const tracked_detection>>;
 

--- a/gst-plugin/src/utils/elapsed_time.h
+++ b/gst-plugin/src/utils/elapsed_time.h
@@ -6,6 +6,8 @@
 #define GSTREAMER1_0_DRPAI_ELAPSED_TIME_H
 
 #include <chrono>
+#include <sstream>
+#include <iomanip>
 
 class elapsed_time {
 
@@ -21,6 +23,16 @@ public:
             auto duration = std::chrono::duration<float>(now - last_time).count();
             last_time = now;
             return duration;
+        }
+
+        static std::string to_string(const std::chrono::time_point<std::chrono::system_clock>& time) {
+            std::ostringstream oss;
+            auto t = std::chrono::system_clock::to_time_t(time);
+            oss << std::put_time(std::localtime(&t), "%FT%T");
+
+            auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(time.time_since_epoch()) % 1000;
+            oss << '.' << std::setfill('0') << std::setw(3) << milliseconds.count() << "Z";
+            return oss.str();
         }
 };
 


### PR DESCRIPTION
In this pull request, I am adding the key `timestamp` to UDP JSON messages.

I also change the time format to `2024-02-12T16:03:45.484Z`. The string formatting used to be specific to the tracking class but I moved it to a more general class `elapsed_time`