### PR TITLE
Use underscore for all JSON keys

### DIFF
--- a/JSON.md
+++ b/JSON.md
@@ -3,8 +3,8 @@ Here is a sample of JSON output when nothing is detected:
 ```json
     {
         "timestamp": "2024-02-12T16:03:45.484Z",
-        "video-rate": 33.3, 
-        "drpai-rate": 2.5, 
+        "video_rate": 33.3, 
+        "drpai_rate": 2.5, 
         "detections": []
     }
 ```
@@ -14,12 +14,12 @@ Here is a sample of JSON output when the filters are **on**:
 ```json
     {
         "timestamp": "2024-02-12T16:03:45.484Z",
-        "video-rate": 25.0, 
-        "drpai-rate": 5.4, 
-        "filter-classes": [
+        "video_rate": 25.0, 
+        "drpai_rate": 5.4, 
+        "filter_classes": [
             "bottle"
         ], 
-        "filter-region": {
+        "filter_region": {
             "left": 450, 
             "top": 350, 
             "width": 100, 
@@ -34,15 +34,15 @@ Here is a sample of JSON output of Yolo models when the tracking is **off**:
 ```json
     {
         "timestamp": "2024-02-12T16:03:45.484Z",
-        "video-rate": 32.3, 
-        "drpai-rate": 2.5, 
+        "video_rate": 32.3, 
+        "drpai_rate": 2.5, 
         "detections": [
             { 
                 "class": "person", 
                 "probability": 0.91, 
                 "box": {
-                    "centerX": 425, 
-                    "centerY": 325, 
+                    "center_x": 425, 
+                    "center_y": 325, 
                     "width": 297, 
                     "height": 282
                 }
@@ -51,8 +51,8 @@ Here is a sample of JSON output of Yolo models when the tracking is **off**:
                 "class": "wine glass", 
                 "probability": 0.52, 
                 "box": {
-                    "centerX": 87, 
-                    "centerY": 133, 
+                    "center_x": 87, 
+                    "center_y": 133, 
                     "width": 122, 
                     "height": 172
                 }
@@ -66,8 +66,8 @@ Here is a sample of JSON output of Yolo models when the tracking is **on**:
 ```json
     {
         "timestamp": "2024-02-12T16:03:45.484Z",
-        "video-rate": 32.3, 
-        "drpai-rate": 2.5, 
+        "video_rate": 32.3, 
+        "drpai_rate": 2.5, 
         "detections": [
             {
                 "id": 2, 
@@ -76,8 +76,8 @@ Here is a sample of JSON output of Yolo models when the tracking is **on**:
                 "class": "person", 
                 "probability": 0.91, 
                 "box": {
-                    "centerX": 425, 
-                    "centerY": 325, 
+                    "center_x": 425, 
+                    "center_y": 325, 
                     "width": 297, 
                     "height": 282
                 }
@@ -89,16 +89,16 @@ Here is a sample of JSON output of Yolo models when the tracking is **on**:
                 "class": "wine glass", 
                 "probability": 0.52, 
                 "box": {
-                    "centerX": 87, 
-                    "centerY": 133, 
+                    "center_x": 87, 
+                    "center_y": 133, 
                     "width": 122, 
                     "height": 172
                 }
             }
         ],
-        "track-history": {
+        "track_history": {
             "minutes": 60,
-            "total-count": 6,
+            "total_count": 6,
             "person": 2,
             "wine glass": 3,
             "chair": 1

--- a/gst-plugin/src/box.cpp
+++ b/gst-plugin/src/box.cpp
@@ -82,8 +82,8 @@ float Box::doa_with(const Box& b) const
 json_object Box::get_json(bool center_origin) const {
     json_object j;
     if (center_origin) {
-        j.add("centerX", x, 0);
-        j.add("centerY", y, 0);
+        j.add("center_x", x, 0);
+        j.add("center_y", y, 0);
     } else {
         j.add("left", getLeft(), 0);
         j.add("top", getTop(), 0);

--- a/gst-plugin/src/drpai-models/drpai_base.cpp
+++ b/gst-plugin/src/drpai-models/drpai_base.cpp
@@ -413,7 +413,7 @@ json_array DRPAI_Base::get_detections_json() const {
 
 json_object DRPAI_Base::get_json() const {
     json_object j;
-    j.add("drpai-rate", rate.get_smooth_rate(), 1);
+    j.add("drpai_rate", rate.get_smooth_rate(), 1);
     j.add("detections", get_detections_json());
     return j;
 }

--- a/gst-plugin/src/drpai-models/drpai_yolo.cpp
+++ b/gst-plugin/src/drpai-models/drpai_yolo.cpp
@@ -368,11 +368,11 @@ json_array DRPAI_Yolo::get_detections_json() const {
 json_object DRPAI_Yolo::get_json() const {
     json_object j = DRPAI_Base::get_json();
     if (!filter_classes.empty())
-        j.add("filter-classes", json_array(filter_classes));
+        j.add("filter_classes", json_array(filter_classes));
     if (filter_region.area() < static_cast<float>(IN_WIDTH * IN_HEIGHT))
-        j.add("filter-region", filter_region.get_json(false));
+        j.add("filter_region", filter_region.get_json(false));
     if(det_tracker.active)
-        j.add("track-history", det_tracker.get_json());
+        j.add("track_history", det_tracker.get_json());
     return j;
 }
 

--- a/gst-plugin/src/drpai_controller.cpp
+++ b/gst-plugin/src/drpai_controller.cpp
@@ -197,7 +197,7 @@ void DRPAI_Controller::thread_function_single() {
     if(socket_fd) {
         json_object j;
         j.add("timestamp", elapsed_time::to_string(std::chrono::system_clock::now()));
-        j.add("video-rate", video_rate.get_smooth_rate(), 1);
+        j.add("video_rate", video_rate.get_smooth_rate(), 1);
         j.concatenate(drpai->get_json());
         const auto str = j.to_string() + "\n";
         auto r = sendto(socket_fd, str.c_str(), str.size(), MSG_DONTWAIT,

--- a/gst-plugin/src/tracker.cpp
+++ b/gst-plugin/src/tracker.cpp
@@ -109,7 +109,7 @@ void tracker::track(const std::vector<detection>& detections) {
 json_object tracker::get_json() const {
     json_object j;
     j.add("minutes", history_length);
-    j.add("total-count", count());
+    j.add("total_count", count());
     for (auto const& [c, name] : names)
         j.add(name, counts.at(c));
     return j;

--- a/gst-plugin/src/utils/json.h
+++ b/gst-plugin/src/utils/json.h
@@ -8,6 +8,7 @@
 #include <iomanip>
 #include <sstream>
 #include <vector>
+#include <algorithm>
 
 class json_base {
 
@@ -51,7 +52,9 @@ public:
 
 private:
     using json_base::add;
-    void add_key(const std::string& key) { add_comma(); s += format_string(key) + ": "; }
+    void add_key(const std::string& key) { add_comma(); s += format_string(format_key(key)) + ": "; }
+    [[nodiscard]] std::string static format_key(const std::string& str)
+    { auto k = str; std::replace(k.begin(), k.end(), ' ', '_'); return k; }
 };
 
 class json_array final: public json_base {


### PR DESCRIPTION
@malcolmdimeglio says:
> looking at the JSON string you send to my module there seems to be multiple syntaxes `video-rate` and `track-history` for instance but also `seen_first` `seen_last` as well as `centerX` and `centerY`
> We should try to keep 1 way to define keys. I suggest using underscores. Also not opposed to camelCase. But definitely not a combination

This pull request changes all JSON keys to underscore syntax.