### PR TITLE
Remove the UDP flag MSG_DONTWAIT

### DIFF
--- a/gst-plugin/src/drpai_controller.cpp
+++ b/gst-plugin/src/drpai_controller.cpp
@@ -199,11 +199,12 @@ void DRPAI_Controller::thread_function_single() {
         j.add("video_rate", video_rate.get_smooth_rate(), 1);
         j.concatenate(drpai->get_json());
         const auto str = j.to_string() + "\n";
-        auto r = sendto(socket_fd, str.c_str(), str.size(), MSG_DONTWAIT,
+        auto r = sendto(socket_fd, str.c_str(), str.size(), 0,
                         reinterpret_cast<const sockaddr *>(&socket_address), sizeof(socket_address));
-        if (r < static_cast<ssize_t>(str.size()))
-//            std::cerr << "[ERROR] Error sending log to the server: " << std::strerror(errno) << std::endl;
-            return;
+        
+        if (r < static_cast<ssize_t>(str.size())) {
+            std::cerr << "[ERROR] Error sending log to the server: " << std::strerror(errno) << std::endl;
+        }
     }
 }
 


### PR DESCRIPTION
The stream sometimes stops sending reports. This is a possible reason that might be related.

According to [here](https://linux.die.net/man/2/sendto), with `MSG_DONTWAIT`, I should have added some handling for return values `EAGAIN` and `EWOULDBLOCK`.

So I just removed the flag.