### PR TITLE
Add UDMA buffer sharing capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The plugin also provides you with the following parameters:
 | **multithread**             | Boolean             |    true | Use a separate thread for object detection.                                                               |
 | **log-detects**             | Boolean             |   false | Print detected objects in standard output.                                                                |
 | **log-exec-time**           | Boolean             |   false | Print execution time into the standard output.                                                            |
+| **share-udma-buf**          | Boolean             |   false | Use a shared buffer for DRP-AI and other gstreamer elements. Note that using this is not recommended alongside `show-fps`, `show-time`, `show-bbox`, and `filter-show` properties. |
 | **log-server**              | Host:Port (String)  |     --- | Address of logs to send in UDP messages in [JSON format](JSON.md) to the specified port on a remote host. |
 | **show-fps**                | Boolean             |   false | Render frame rates of video and DRPAI at the corner of the video.                                         |
 | **show-time**               | Boolean             |    true | Render the current time at the corner of the video.                                                       |

--- a/gst-plugin/meson.build
+++ b/gst-plugin/meson.build
@@ -8,12 +8,13 @@ cdata.set_quoted('GST_API_VERSION', api_version)
 cdata.set_quoted('GST_PACKAGE_NAME', 'GStreamer DRP-AI Plug-in')
 cdata.set_quoted('GST_PACKAGE_ORIGIN', 'https://mistysom.com')
 cdata.set('HAVE_MMNGR', enable_mmngr.enabled())
-configure_file(output : 'config.h', configuration : cdata)
+configure_file(output: 'config.h', configuration: cdata)
 
 incdir = include_directories('src')
 
 plugin_sources = [
   'src/gstdrpai.cpp',
+  'src/gst_udma_buffer_pool.cpp',
   'src/drpai_controller.cpp',
   'src/tracker.cpp',
   'src/filterer.cpp',
@@ -21,25 +22,24 @@ plugin_sources = [
   'src/drivers/drpai_native.cpp',
   'src/drpai-models/base_post_processor.cpp',
   'src/image.cpp',
-  'src/box.cpp'
- ]
-
-plugin_dependencies = [
-  gst_dep, thread_dep, dl_dep, mmngr_dep, mmngrbuf_dep
+  'src/box.cpp',
 ]
+
+plugin_dependencies = [gst_dep, thread_dep, dl_dep, mmngr_dep, mmngrbuf_dep]
 
 subdir('src/drivers/drpai-tvm')
 
-gstplugindrpai = library('gstdrpai',
+gstplugindrpai = library(
+  'gstdrpai',
   plugin_sources,
   c_args: plugin_c_args,
   cpp_args: plugin_c_args,
-  dependencies : plugin_dependencies,
-  install : true,
+  dependencies: plugin_dependencies,
+  install: true,
   include_directories: incdir,
-  install_dir : join_paths(get_option('libdir'), 'gstreamer-1.0'),
+  install_dir: join_paths(get_option('libdir'), 'gstreamer-1.0'),
 )
-gstdrpai_dep = declare_dependency(link_with : gstplugindrpai, include_directories : incdir)
+gstdrpai_dep = declare_dependency(link_with: gstplugindrpai, include_directories: incdir)
 
 subdir('src/drpai-models/drpai-yolo')
 subdir('src/drpai-models/drpai-dummy')

--- a/gst-plugin/src/consts.h
+++ b/gst-plugin/src/consts.h
@@ -27,3 +27,6 @@ constexpr static uint8_t  PERCENT_MUL  = 100;
 constexpr static uint16_t SEC_PER_MIN  = 60;
 constexpr static uint16_t MIN_PER_HOUR = 60;
 constexpr static uint16_t SEC_PER_HOUR = SEC_PER_MIN * MIN_PER_HOUR;
+
+constexpr static auto WARNING = "\n\x1b[33m[WARNING]\x1b[0m : ";
+constexpr static auto ERROR   = "\n\x1b[33m[ERROR]\x1b[0m : ";

--- a/gst-plugin/src/drivers/dmabuf.cpp
+++ b/gst-plugin/src/drivers/dmabuf.cpp
@@ -5,38 +5,79 @@
 #include "dmabuf.h"
 #include <cstring>
 #include <iostream>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include "config.h"
+#include "consts.h"
 
-/* This block of code is only accessible from C code. */
 #ifdef HAVE_MMNGR
+/* This block of code is only accessible from C code. */
 extern "C" {
 #include "mmngr_buf_user_public.h"
 #include "mmngr_user_public.h"
 }
+#else
+#include <fcntl.h>
+#include <fstream>
+#include <sys/mman.h>
+#include <unistd.h>
 #endif
+
+/* Instance of DMABuffer for singleton design pattern */
+static std::unique_ptr<DMABuffer> singleton_instance;
+
+DMABuffer *DMABuffer::instance(uint32_t buf_size)
+{
+    if (singleton_instance == nullptr) {
+        singleton_instance = std::make_unique<DMABuffer>(buf_size);
+    }
+    return singleton_instance.get();
+}
+
+void DMABuffer::release()
+{
+    if (singleton_instance != nullptr) {
+        singleton_instance.reset();
+    }
+}
+
 
 DMABuffer::DMABuffer(const uint32_t buf_size) : size(buf_size)
 {
 #ifdef HAVE_MMNGR
-    MMNGR_ID id       = 0;
-    int      m_dma_fd = 0;
+    MMNGR_ID id = 0;
 
     int ret = mmngr_alloc_in_user_ext(&idx, size, &phy_addr, &mem, MMNGR_VA_SUPPORT_CACHED, nullptr);
     if (ret < 0) {
-        throw std::runtime_error("[ERROR] Can't allocate user ext in mmngr: " + std::to_string(ret));
+        throw std::runtime_error("Can't allocate user ext in mmngr: " + std::to_string(ret));
     }
 
     // Write once to allocate physical memory to u-dma-buf virtual space.
     std::memset(mem, 0, size);
 
-    ret = mmngr_export_start_in_user_ext(&id, size, phy_addr, &m_dma_fd, nullptr);
+    ret = mmngr_export_start_in_user_ext(&id, size, phy_addr, &fd, nullptr);
     if (ret < 0) {
-        throw std::runtime_error("[ERROR] Can't export start user ext in mmngr: " + std::to_string(ret));
+        throw std::runtime_error("Can't export start user ext in mmngr: " + std::to_string(ret));
     }
 #else
-    mem = malloc(size);
+
+    std::ifstream phy_addr_file("/sys/class/u-dma-buf/udmabuf0/phys_addr");
+    phy_addr_file >> std::hex >> phy_addr;
+    phy_addr_file.close();
+
+    fd = open("/dev/udmabuf0", O_RDWR);
+    if (fd == -1) {
+        throw std::runtime_error("UDMA open failed: " + std::string(strerror(errno)));
+    }
+
+    mem = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (mem == MAP_FAILED) {
+        throw std::runtime_error("UDMA mmap failed: " + std::string(strerror(errno)));
+    }
+
+    // Write once to allocate physical memory to u-dma-buf virtual space.
+    std::memset(mem, 0, size);
 #endif
 }
 
@@ -44,10 +85,17 @@ DMABuffer::~DMABuffer()
 {
 #ifdef HAVE_MMNGR
     if (const int ret = mmngr_free_in_user_ext(idx); ret < 0) {
-        std::cerr << "[ERROR] Can't free user ext in mmngr: " << ret << std::endl;
+        std::cerr << ERROR << "Can't free user ext in mmngr: " << ret << std::endl;
     }
 #else
-    free(mem);
+    if (const int ret = munmap(mem, size); ret < 0) {
+        std::cerr << ERROR << "Can't unmap UDMA memory: " << ret << std::endl;
+    }
+    if (fd > 0) {
+        if (const int ret = close(fd); ret < 0) {
+            std::cerr << ERROR << "Can't close UDMA file descriptor: " << ret << std::endl;
+        }
+    }
 #endif
 }
 
@@ -57,7 +105,7 @@ void DMABuffer::flush() const
 {
 #ifdef HAVE_MMNGR
     if (const int ret = mmngr_flush(idx, 0, size); ret < 0) {
-        throw std::runtime_error("[ERROR] Can't flush mmngr: " + std::to_string(ret));
+        throw std::runtime_error("Can't flush mmngr: " + std::to_string(ret));
     }
 #endif
 }

--- a/gst-plugin/src/drivers/dmabuf.h
+++ b/gst-plugin/src/drivers/dmabuf.h
@@ -9,6 +9,10 @@
 class DMABuffer
 {
 public:
+    /* Singleton design pattern functions */
+    static DMABuffer *instance(uint32_t buf_size);
+    static void       release();
+
     explicit DMABuffer(uint32_t buf_size);
     ~DMABuffer();
 
@@ -27,6 +31,8 @@ public:
 private:
     /* The index of the buffer. */
     int idx = 0;
+    /* The file descriptor of the buffer */
+    int fd = 0;
     /* The size of the buffer in bytes. */
     const uint32_t size;
     /* The physical address of DMA buffer. */

--- a/gst-plugin/src/drpai_controller.cpp
+++ b/gst-plugin/src/drpai_controller.cpp
@@ -4,27 +4,46 @@
 
 #include "drpai_controller.h"
 
+#include "consts.h"
+#include "drivers/dmabuf.h"
 #include "drivers/drpai_native.h"
 #include "drpai-models/base_post_processor.h"
 #ifdef ENABLE_TVM
 #include "drivers/drpai-tvm/drpai_tvm.h"
 #endif
-#include <dlfcn.h>
-#include <fcntl.h>
-#include <netdb.h>
-#include <unistd.h>
-
 #include <chrono>
 #include <cstring>
+#include <dlfcn.h>
+#include <fcntl.h>
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <netdb.h>
+#include <unistd.h>
 
 void DRPAI_Controller::open_resources()
 {
     if (drpai->rate.get_max_rate() == 0) {
         std::cout << "[WARNING] DRPAI is disabled by the zero max framerate." << std::endl;
         return;
+    }
+    if (share_udma_buffer) {
+        if (show_fps || show_time || show_bbox || show_filter) {
+            std::cout << WARNING << "Using these properties while sharing the UDMA buffer is not recommended:";
+            if (show_fps) {
+                std::cout << " show-fps";
+            }
+            if (show_time) {
+                std::cout << " show-time";
+            }
+            if (show_bbox) {
+                std::cout << " show-bbox";
+            }
+            if (show_filter) {
+                std::cout << " filter-show";
+            }
+            std::cout << "\n" << std::endl;
+        }
     }
 
     if (multithread) {
@@ -52,7 +71,9 @@ void DRPAI_Controller::process_image(uint8_t *img_data, uint32_t img_data_len)
                 throw std::exception();
 
             case Ready:
-                image_mapped_udma->copy(img_data, img_data_len, BGR_DATA);
+                if (!share_udma_buffer) {
+                    image_mapped_udma->copy(img_data, img_data_len, BGR_DATA);
+                }
                 // std::this_thread::sleep_for(std::chrono::milliseconds(50));
                 thread_state = Processing;
                 if (multithread) {
@@ -167,10 +188,9 @@ void DRPAI_Controller::open_resources_with_image_size(uint16_t image_width, uint
         throw std::runtime_error(std::string("[ERROR] The model only supports image input with resolution ") +
                                  std::to_string(drpai->IN_WIDTH) + "x" + std::to_string(drpai->IN_HEIGHT));
     }
-    image_mapped_udma =
-            std::make_unique<Image>(image_width, image_height, drpai->IN_CHANNEL, drpai->IN_FORMAT, nullptr);
+    image_mapped_udma = std::make_unique<Image>(image_width, image_height, drpai->IN_CHANNEL, drpai->IN_FORMAT);
     image_mapped_udma->map_dma_buffer();
-    drpai->set_data_in_address(image_mapped_udma->get_dma_buffer_physical_address());
+    drpai->set_data_in_address(DMABuffer::instance(image_mapped_udma->size)->get_physical_address());
 
     postprocessor->open_resource(drpai->drpai_output_buf.size(), image_width, image_height, labels.size());
 
@@ -197,6 +217,7 @@ void DRPAI_Controller::release_resources()
 
     drpai->release_resource();
     image_mapped_udma.reset();
+    DMABuffer::release();
     dlclose(dynamic_library_handle);
 }
 
@@ -234,7 +255,9 @@ void DRPAI_Controller::thread_function_single()
         }
         const auto t1 = std::chrono::high_resolution_clock::now();
 
-        image_mapped_udma->prepare();
+        if (!share_udma_buffer) {
+            image_mapped_udma->prepare();
+        }
         const auto t2 = std::chrono::high_resolution_clock::now();
 
         drpai->run_inference();
@@ -378,6 +401,9 @@ void DRPAI_Controller::set_property(GstDRPAI_Properties prop, const GValue *valu
         case PROP_LOG_EXEC_TIME:
             log_exec_time = g_value_get_boolean(value) == TRUE;
             break;
+        case PROP_SHARE_UDMA_BUF:
+            share_udma_buffer = g_value_get_boolean(value) == TRUE;
+            break;
         case PROP_TRACKING:
             det_tracker.active = g_value_get_boolean(value) == TRUE;
             if (det_tracker.active) {
@@ -473,6 +499,9 @@ void DRPAI_Controller::get_property(GstDRPAI_Properties prop, GValue *value) con
             break;
         case PROP_LOG_EXEC_TIME:
             g_value_set_boolean(value, log_exec_time ? TRUE : FALSE);
+            break;
+        case PROP_SHARE_UDMA_BUF:
+            g_value_set_boolean(value, share_udma_buffer ? TRUE : FALSE);
             break;
         case PROP_TRACKING:
             g_value_set_boolean(value, det_tracker.active ? TRUE : FALSE);
@@ -577,7 +606,12 @@ void DRPAI_Controller::install_properties(std::map<GstDRPAI_Properties, GParamSp
                                                         "Send UDP messages in JSON about detected "
                                                         "objects to the mentioned host:port.",
                                                         nullptr, G_PARAM_WRITABLE));
-
+    params.emplace(PROP_SHARE_UDMA_BUF,
+                   g_param_spec_boolean("share_udma_buf", "Share UDMA Buffer",
+                                        "Use a shared buffer for DRP-AI and other gstreamer elements. "
+                                        "Note that using this is not recommended alongside `show-fps`, `show-time`, "
+                                        "`show-bbox`, and `filter-show` properties.",
+                                        FALSE, G_PARAM_READWRITE));
     params.emplace(PROP_TRACKING, g_param_spec_boolean("tracking", "Tracking",
                                                        "Track detected objects based on their previous locations. Each "
                                                        "detected object gets an ID that persists across multiple "

--- a/gst-plugin/src/drpai_controller.h
+++ b/gst-plugin/src/drpai_controller.h
@@ -45,14 +45,15 @@ public:
     static void install_properties(std::map<GstDRPAI_Properties, GParamSpec *> &params);
 
 private:
-    bool            multithread   = true;
-    bool            show_fps      = false;
-    bool            show_time     = false;
-    bool            show_bbox     = true;
-    bool            show_track_id = false;
-    bool            show_filter   = false;
-    bool            log_exec_time = false;
-    bool            log_detects   = false; /// Log detections in the standard output.
+    bool            multithread       = true;
+    bool            show_fps          = false;
+    bool            show_time         = false;
+    bool            show_bbox         = true;
+    bool            show_track_id     = false;
+    bool            show_filter       = false;
+    bool            log_exec_time     = false;
+    bool            log_detects       = false; /// Log detections in the standard output.
+    bool            share_udma_buffer = false;
     rate_controller video_rate;
     tracker         det_tracker;
     filterer        det_filterer;

--- a/gst-plugin/src/gst_udma_buffer_pool.cpp
+++ b/gst-plugin/src/gst_udma_buffer_pool.cpp
@@ -1,0 +1,37 @@
+#include "gst_udma_buffer_pool.h"
+#include <iostream>
+#include "drivers/dmabuf.h"
+
+struct Gst_UDMA_BufferPoolClass : GstBufferPoolClass {
+};
+
+G_DEFINE_TYPE(Gst_UDMA_BufferPool, gst_udma_buffer_pool, GST_TYPE_BUFFER_POOL);
+
+GstFlowReturn gst_udma_buffer_pool_alloc_buffer(GstBufferPool *pool, GstBuffer **buffer,
+                                                GstBufferPoolAcquireParams *params)
+{
+    // auto *const    udma_buffer_pool = reinterpret_cast<Gst_UDMA_BufferPool *>(pool);
+    constexpr auto imageLength = 640 * 480 * 3;
+
+    std::cout << "\tUDMA Buffer allocated by other gstreamer elements." << std::endl;
+
+    auto *const mem_ptr = DMABuffer::instance(imageLength)->get_mem();
+
+    *buffer = gst_buffer_new_wrapped(mem_ptr, imageLength);
+
+    return GST_FLOW_OK;
+}
+
+void gst_udma_buffer_pool_class_init(Gst_UDMA_BufferPoolClass *klass)
+{
+    auto *buffer_pool_class = GST_BUFFER_POOL_CLASS(klass);
+
+    buffer_pool_class->alloc_buffer = gst_udma_buffer_pool_alloc_buffer;
+}
+
+void gst_udma_buffer_pool_init(Gst_UDMA_BufferPool *self) {}
+
+Gst_UDMA_BufferPool *gst_udma_buffer_pool_new()
+{
+    return static_cast<Gst_UDMA_BufferPool *>(g_object_new(gst_udma_buffer_pool_get_type(), nullptr));
+}

--- a/gst-plugin/src/gst_udma_buffer_pool.h
+++ b/gst-plugin/src/gst_udma_buffer_pool.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <gst/gstbufferpool.h>
+
+struct Gst_UDMA_BufferPool : public GstBufferPool {
+};
+
+Gst_UDMA_BufferPool *gst_udma_buffer_pool_new();

--- a/gst-plugin/src/gstdrpai.cpp
+++ b/gst-plugin/src/gstdrpai.cpp
@@ -64,13 +64,44 @@
 #include <iostream>
 #include "drivers/drpai_native.h"
 #include "drpai_controller.h"
+#include "gst_udma_buffer_pool.h"
 #include "gstdrpai.h"
 #include "image.h"
 #include "properties.h"
 
+static gboolean gst_drpai_sink_query(GstPad *pad, GstObject *parent, GstQuery *query)
+{
+    std::cout << "DRP-AI received query: " << GST_QUERY_TYPE_NAME(query) << std::endl;
+    auto *const obj = GST_PLUGIN_DRPAI(parent);
+
+    switch (query->type) {
+        case GST_QUERY_ALLOCATION: {
+            GstCaps *caps      = nullptr;
+            gboolean need_pool = FALSE;
+            gst_query_parse_allocation(query, &caps, &need_pool);
+
+            if (need_pool == TRUE && obj->udma_buffer_pool != nullptr) {
+                std::cout << "\tNeed a pool for " << gst_caps_to_string(caps) << std::endl;
+
+                gst_query_add_allocation_pool(query, obj->udma_buffer_pool.get(), 1, 0, 1);
+
+                std::cout << "\tUDMA buffer allocation pool provided." << std::endl;
+
+                // obj->drpai_controller->validate_properties();
+                return TRUE;
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
+    return FALSE;
+}
+
 static GstStateChangeReturn gst_drpai_change_state(GstElement *element, const GstStateChange transition)
 {
-    const auto          *obj                  = GST_PLUGIN_DRPAI(&element->object);
+    auto                *obj                  = GST_PLUGIN_DRPAI(&element->object);
     auto *const          parent_element_class = GST_ELEMENT_CLASS(parent_class);
     GstStateChangeReturn ret                  = GST_STATE_CHANGE_SUCCESS;
 
@@ -79,12 +110,14 @@ static GstStateChangeReturn gst_drpai_change_state(GstElement *element, const Gs
             case GST_STATE_CHANGE_NULL_TO_READY:
                 /* open the device */
                 obj->drpai_controller->open_resources();
+                obj->udma_buffer_pool.reset(gst_udma_buffer_pool_new());
                 ret = parent_element_class->change_state(element, transition);
                 break;
             case GST_STATE_CHANGE_READY_TO_NULL:
                 ret = parent_element_class->change_state(element, transition);
                 /* close the device */
                 obj->drpai_controller->release_resources();
+                obj->udma_buffer_pool.reset();
                 break;
             default:
                 ret = parent_element_class->change_state(element, transition);
@@ -147,7 +180,7 @@ static gboolean gst_drpai_sink_event(GstPad *pad, GstObject *parent, GstEvent *e
     gboolean    ret = TRUE;
     auto *const obj = GST_PLUGIN_DRPAI(parent);
 
-    GST_LOG_OBJECT(obj, "Received %s event: %" GST_PTR_FORMAT, GST_EVENT_TYPE_NAME(event), event);
+    std::cout << "DRP-AI received event from sink: " << GST_EVENT_TYPE_NAME(event) << std::endl;
 
     switch (GST_EVENT_TYPE(event)) {
         case GST_EVENT_CAPS: {
@@ -215,6 +248,7 @@ static void gst_drpai_init(GstDRPAI *self)
 {
     self->sinkpad = gst_pad_new_from_static_template(&sink_factory, "sink");
     gst_pad_set_event_function(self->sinkpad, GST_DEBUG_FUNCPTR(gst_drpai_sink_event));
+    gst_pad_set_query_function(self->sinkpad, GST_DEBUG_FUNCPTR(gst_drpai_sink_query));
     gst_pad_set_chain_function(self->sinkpad, GST_DEBUG_FUNCPTR(gst_drpai_chain));
     GST_PAD_SET_PROXY_CAPS(self->sinkpad);
     gst_element_add_pad(GST_ELEMENT(self), self->sinkpad);
@@ -266,15 +300,6 @@ static gboolean plugin_init(GstPlugin *plugin)
     GST_DEBUG_CATEGORY_INIT(gst_drpai_debug, "drpai", 0, "DRP-AI plugin");
     return gst_element_register(plugin, "drpai", GST_RANK_NONE, GST_TYPE_PLUGIN_DRPAI);
 }
-
-/* PACKAGE: this is usually set by meson depending on some _INIT macro
- * in meson.build and then written into and defined in config.h, but we can
- * just set it ourselves here in case someone doesn't use meson to
- * compile this code. GST_PLUGIN_DEFINE needs PACKAGE to be defined.
- */
-#ifndef PACKAGE
-#define PACKAGE "myfirstplugin"
-#endif
 
 /* gstreamer looks for this structure to register plugins */
 GST_PLUGIN_DEFINE(GST_VERSION_MAJOR, GST_VERSION_MINOR, drpai, "DRP-AI Plug-in", plugin_init, PACKAGE_VERSION,

--- a/gst-plugin/src/gstdrpai.h
+++ b/gst-plugin/src/gstdrpai.h
@@ -55,14 +55,16 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE(GstDRPAI, gst_drpai, GST, PLUGIN_DRPAI, GstElement)
 
 class DRPAI_Controller;
+struct Gst_UDMA_BufferPool;
 
 struct _GstDRPAI : GstElement {
-    GstPad *sinkpad;
-    GstPad *srcpad;
+    GstPad *sinkpad = nullptr;
+    GstPad *srcpad  = nullptr;
 
-    bool stop_error;
+    bool stop_error = true;
 
-    std::unique_ptr<DRPAI_Controller> drpai_controller;
+    std::unique_ptr<Gst_UDMA_BufferPool> udma_buffer_pool;
+    std::unique_ptr<DRPAI_Controller>    drpai_controller;
 };
 
 GST_DEBUG_CATEGORY_STATIC(gst_drpai_debug);

--- a/gst-plugin/src/image.cpp
+++ b/gst-plugin/src/image.cpp
@@ -21,7 +21,7 @@ constexpr static int32_t  TEXT_CHAR_HEIGHT = 8;
 constexpr static int32_t  TEXT_STR_HEIGHT  = TEXT_CHAR_HEIGHT + (2 * TEXT_MARGIN);
 
 Image::Image(const uint32_t w, const uint32_t h, const uint32_t c, const IMAGE_FORMAT format, uint8_t *data) :
-    img_buffer(data), img_w(w), img_h(h), img_c(c), dma_buffer(nullptr), format(format), size(img_w * img_h * img_c),
+    img_buffer(data), img_w(w), img_h(h), img_c(c), size(img_w * img_h * img_c), format(format),
     convert_from_format(format)
 {
 }
@@ -41,8 +41,8 @@ Image::~Image() = default;
  ******************************************/
 void Image::map_dma_buffer()
 {
-    dma_buffer = std::make_unique<DMABuffer>(size);
-    img_buffer = dma_buffer->get_mem();
+    mapped_dma_buffer = DMABuffer::instance(size);
+    img_buffer        = mapped_dma_buffer->get_mem();
 }
 
 void Image::copy(const uint8_t *data, uint32_t data_len, IMAGE_FORMAT f)
@@ -341,8 +341,8 @@ void Image::prepare()
             convert_from_format = format;
         }
     }
-    if (dma_buffer != nullptr) {
-        dma_buffer->flush();
+    if (mapped_dma_buffer != nullptr) {
+        mapped_dma_buffer->flush();
     }
 }
 
@@ -383,8 +383,6 @@ void Image::render_text_at_corner(const std::vector<std::string> &corner_text) c
         line++;
     }
 }
-
-uint32_t Image::get_dma_buffer_physical_address() const { return dma_buffer->get_physical_address(); }
 
 inline static void write_u16(std::vector<char> &buffer, uint16_t value)
 {

--- a/gst-plugin/src/image.h
+++ b/gst-plugin/src/image.h
@@ -13,7 +13,7 @@ enum IMAGE_FORMAT : std::uint8_t { BGR_DATA, RGB_DATA, YUV_DATA };
 class Image
 {
 public:
-    explicit Image(uint32_t w, uint32_t h, uint32_t c, IMAGE_FORMAT format, uint8_t *data);
+    explicit Image(uint32_t w, uint32_t h, uint32_t c, IMAGE_FORMAT format, uint8_t *data = nullptr);
     ~Image();
 
     Image(const Image &)            = delete;
@@ -42,17 +42,15 @@ public:
     /// @param [in] corner_text Reference to the array of strings to be rendered at the corner of the image.
     void render_text_at_corner(std::vector<std::string> const &corner_text) const;
 
-    [[nodiscard]] uint32_t get_dma_buffer_physical_address() const;
-
     uint8_t       *img_buffer = nullptr;
     const uint32_t img_w;
     const uint32_t img_h;
     const uint32_t img_c;
+    const uint32_t size;
 
 private:
-    std::unique_ptr<DMABuffer> dma_buffer;
-    IMAGE_FORMAT               format;
-    uint32_t                   size;
+    IMAGE_FORMAT format;
+    DMABuffer   *mapped_dma_buffer = nullptr;
 
     /* converting section */
     constexpr static uint32_t  BGR_NUM_CHANNEL  = 3;

--- a/gst-plugin/src/properties.h
+++ b/gst-plugin/src/properties.h
@@ -18,6 +18,7 @@ enum GstDRPAI_Properties : std::uint8_t {
     PROP_STOP_ERROR,
     PROP_LOG_SERVER,
     PROP_LOG_EXEC_TIME,
+    PROP_SHARE_UDMA_BUF,
 
     PROP_TRACKING,
     PROP_SHOW_TRACK_ID,


### PR DESCRIPTION
Enables the sharing of the UDMA buffer between the DRP-AI plugin and other GStreamer elements.

This feature allows other elements in the pipeline to directly access the buffer allocated for DRP-AI processing, potentially improving efficiency when rendering on the image is not important.

More noticeably this PR has these changes:

- Adds a new `share_udma_buf` property to control this behavior.

- Introduces a new GStreamer buffer pool implementation to handle UDMA buffer allocation.

- Adds a warning message when `share_udma_buf` is enabled alongside properties that are incompatible, such as rendering framerate, time or bounding boxes.

### How to enable

Run the pipeline like below:

> gst-launch-1.0 v4l2src device=/dev/video0 **io-mode=userptr** ! drpai model=yolov3 **share-udma-buf=true** ! fakesink