### PR TITLE
Add the missing mutex lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         sed -i -e 's/bitbake mistysom-image/bitbake gst-launch-split gstreamer1.0-drpai gstreamer1.0-drpai-yolo/g' rzv2l/Build/exec.sh
         sed -i -e 's|/tmp/deploy/images/|/tmp/deploy/rpm/aarch64/*|g' rzv2l/Build/exec.sh
         sed -i '/image/d' rzv2l/Build/exec.sh
+        sed -i '/rm /d' rzv2l/Build/exec.sh
 
     - name: Build the Docker image
       run: cd rzv2l/Build && ./build.sh;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       run: |
         sed -i -e 's/bitbake mistysom-image/bitbake gst-launch-split gstreamer1.0-drpai gstreamer1.0-drpai-yolo/g' rzv2l/Build/exec.sh
         sed -i -e 's|/tmp/deploy/images/|/tmp/deploy/rpm/aarch64/*|g' rzv2l/Build/exec.sh
+        sed -i '/image/d' rzv2l/Build/exec.sh
 
     - name: Build the Docker image
       run: cd rzv2l/Build && ./build.sh;

--- a/gst-plugin/src/drpai-models/drpai-yolo/drpai_yolo.cpp
+++ b/gst-plugin/src/drpai-models/drpai-yolo/drpai_yolo.cpp
@@ -302,14 +302,14 @@ void DRPAI_Yolo::add_corner_text() {
     }
 }
 
-json_array DRPAI_Yolo::get_detections_json() const {
+json_array DRPAI_Yolo::get_detections_json() {
     if (det_tracker.active)
         return det_tracker.get_detections_json();
     else
         return DRPAI_Base::get_detections_json();
 }
 
-json_object DRPAI_Yolo::get_json() const {
+json_object DRPAI_Yolo::get_json() {
     json_object j = DRPAI_Base::get_json();
     if (filterer.is_active())
         j.add("filter", filterer.get_json());

--- a/gst-plugin/src/drpai-models/drpai-yolo/drpai_yolo.h
+++ b/gst-plugin/src/drpai-models/drpai-yolo/drpai_yolo.h
@@ -19,8 +19,8 @@ public:
     void render_detections_on_image(Image &img) override;
     void add_corner_text() override;
 
-    [[nodiscard]] json_array get_detections_json() const override;
-    [[nodiscard]] json_object get_json() const override;
+    [[nodiscard]] json_array get_detections_json() override;
+    [[nodiscard]] json_object get_json() override;
 
     void set_property(GstDRPAI_Properties prop, const GValue* value) override;
     void get_property(GstDRPAI_Properties prop, GValue* value) const override;

--- a/gst-plugin/src/drpai-models/drpai_base.cpp
+++ b/gst-plugin/src/drpai-models/drpai_base.cpp
@@ -370,6 +370,7 @@ void DRPAI_Base::release_resource() {
 }
 
 void DRPAI_Base::render_detections_on_image(Image &img) {
+    std::unique_lock lock (mutex);
     for (const auto& detection: last_det)
     {
         /* Draw the bounding box on the image */
@@ -387,14 +388,15 @@ void DRPAI_Base::add_corner_text() {
     corner_text.push_back("DRPAI Rate: " + (drpai_fd ? std::to_string(static_cast<int>(rate.get_smooth_rate())) + " fps" : "N/A"));
 }
 
-json_array DRPAI_Base::get_detections_json() const {
+json_array DRPAI_Base::get_detections_json() {
+    std::unique_lock lock (mutex);
     json_array a;
     for(auto det: last_det)
         a.add(det.get_json());
     return a;
 }
 
-json_object DRPAI_Base::get_json() const {
+json_object DRPAI_Base::get_json() {
     json_object j;
     j.add("drpai_rate", rate.get_smooth_rate(), 1);
     j.add("detections", get_detections_json());

--- a/gst-plugin/src/drpai-models/drpai_base.h
+++ b/gst-plugin/src/drpai-models/drpai_base.h
@@ -62,8 +62,8 @@ public:
 
     virtual void add_corner_text();
     virtual void extract_detections() = 0;
-    [[nodiscard]] virtual json_array get_detections_json() const;
-    [[nodiscard]] virtual json_object get_json() const;
+    [[nodiscard]] virtual json_array get_detections_json();
+    [[nodiscard]] virtual json_object get_json();
 
     virtual void set_property(GstDRPAI_Properties prop, const GValue* value);
     virtual void get_property(GstDRPAI_Properties prop, GValue* value) const;


### PR DESCRIPTION
I noticed the library crashes when `multithread=true` and `tracking=false`.

Then I found that I was missing a mutex lock. This pull request fixes it.