### PR TITLE
Change bitmap-save-minutes and bitmap-save-probability to float

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       run: cd rzv2l/Build && ./run.sh -c /home/github/rzv2l-cache;
       
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: rpm-files
         path: |

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ The plugin also provides you with the following parameters:
 | **show-bbox**               | Boolean             |    true | Render the latest detection bounding boxes on the video.                                                  |
 | **stop-error**              | Boolean             |    true | Stop the gstreamer if kernel modules fail to open.                                                        |
 | **max-video-rate**          | Float [0.001 - 120] |     120 | Force maximum video frame rate using thread sleeps.                                                       |
-| **max-drpai-rate**          | Float [0 - 120]     |     120 | Force maximum DRPAI frame rate using thread sleeps.                                                       |
+| **max-drpai-rate**          | Float [0 - 120]     |     120 | Force maximum DRPAI frame rate using thread sleeps. Zero means DRPAI is disabled.                         |
 | **smooth-video-rate**       | Float [1 - 1000]    |       1 | Number of last video frame rates to average for a more smooth value.                                      |
 | **smooth-drpai-rate**       | Float [1 - 1000]    |       1 | Number of last DRPAI frame rates to average for a more smooth value.                                      |
 | **bitmap-save-dir**         | String              |   `"."` | The directory path to save bitmap images for fewer probability detections.                                |
-| **bitmap-save-minutes**     | Integer [1 - 1000]  |       5 | Minutes between each bitmap save for fewer probability detections.                                        |
-| **bitmap-save-probability** | Integer [0 - 100]   |       0 | The maximum detection probability that triggers the bitmap saving for detections.                         |
+| **bitmap-save-minutes**     | Float [0 - 1000]    |       5 | Minutes between each bitmap save for fewer probability detections. Zero means every frame.                |
+| **bitmap-save-probability** | Float [0 - 100]     |       0 | The maximum detection probability that triggers the bitmap saving for detections. Zero means disabled.    |
 | **bitmap-save-classes**     | String              |    `""` | A comma seperated list of classes that triggers the bitmap saving for detections.                         |
 | **post-process-properties** | String              |     --- | A semi-colon seperated properties used in post-processor library.                                         |
 

--- a/gst-plugin/src/drpai-models/drpai-yolo/yolo_post_processor.h
+++ b/gst-plugin/src/drpai-models/drpai-yolo/yolo_post_processor.h
@@ -29,13 +29,6 @@ public:
 
 private:
     float TH_PROB = 0.5f;
-
-    bool show_track_id = false;
-    tracker det_tracker;
-
-    bool show_filter = false;
-    detection_filterer filterer;
-
     float MODEL_IN_W = 0;
     float MODEL_IN_H = 0;
     char yolo_version = 0;
@@ -45,6 +38,12 @@ private:
     uint32_t sum_grids = 0;
     std::vector<float> anchors {};
     std::vector<std::string> labels {};
+
+    bool show_track_id = false;
+    tracker det_tracker;
+
+    bool show_filter = false;
+    detection_filterer filterer;
 
     void load_label_file(const std::string& label_file_name);
     void load_anchors_file(const std::string& anchors_file_name);

--- a/gst-plugin/src/drpai_controller.cpp
+++ b/gst-plugin/src/drpai_controller.cpp
@@ -319,10 +319,10 @@ void DRPAI_Controller::set_property(GstDRPAI_Properties prop, const GValue *valu
             bitmap_save_directory = g_value_get_string(value);
             break;
         case PROP_BITMAP_SAVE_MINUTES:
-            bitmap_save_time_between = g_value_get_uint(value);
+            bitmap_save_time_between = g_value_get_float(value);
             break;
         case PROP_BITMAP_SAVE_PROB:
-            bitmap_save_class_probability = static_cast<float>(g_value_get_uint(value))/100.f;
+            bitmap_save_class_probability = g_value_get_float(value)/100.f;
             break;
         case PROP_BITMAP_SAVE_CLASS: {
             bitmap_save_classes.clear();
@@ -369,10 +369,10 @@ void DRPAI_Controller::get_property(GstDRPAI_Properties prop, GValue *value) con
             g_value_set_string(value, bitmap_save_directory.c_str());
             break;
         case PROP_BITMAP_SAVE_MINUTES:
-            g_value_set_uint(value, bitmap_save_time_between);
+            g_value_set_float(value, bitmap_save_time_between);
             break;
         case PROP_BITMAP_SAVE_PROB:
-            g_value_set_uint(value, static_cast<guint>(bitmap_save_class_probability*100));
+            g_value_set_float(value, bitmap_save_class_probability*100);
             break;
         case PROP_BITMAP_SAVE_CLASS: {
             std::string s;
@@ -427,10 +427,10 @@ void DRPAI_Controller::install_properties(std::map<GstDRPAI_Properties, _GParamS
     params.emplace(PROP_BITMAP_SAVE_DIR, g_param_spec_string("bitmap_save_dir", "Bitmap Save Directory",
                                                             "The directory path to save bitmap images for fewer probability detections.",
                                                             "", G_PARAM_READWRITE));
-    params.emplace(PROP_BITMAP_SAVE_MINUTES, g_param_spec_uint("bitmap_save_minutes", "Bitmap Save Minutes",
+    params.emplace(PROP_BITMAP_SAVE_MINUTES, g_param_spec_float("bitmap_save_minutes", "Bitmap Save Minutes",
                                                                "Minutes between each bitmap save for fewer probability detections.",
-                                                               1, 1000, 5, G_PARAM_READWRITE));
-    params.emplace(PROP_BITMAP_SAVE_PROB, g_param_spec_uint("bitmap_save_probability", "Bitmap Save Class Probability",
+                                                               0, 1000, 5, G_PARAM_READWRITE));
+    params.emplace(PROP_BITMAP_SAVE_PROB, g_param_spec_float("bitmap_save_probability", "Bitmap Save Class Probability",
                                                             "The maximum detection probability that triggers the bitmap saving for detections.",
                                                             0, 100, 0, G_PARAM_READWRITE));
     params.emplace(PROP_BITMAP_SAVE_CLASS, g_param_spec_string("bitmap_save_classes", "Bitmap Save Classes",
@@ -442,7 +442,7 @@ void DRPAI_Controller::install_properties(std::map<GstDRPAI_Properties, _GParamS
 void DRPAI_Controller::check_save_bmp() {
     // Skip frequent saves
     const auto now = std::chrono::system_clock::now();
-    const auto time_duration = std::chrono::duration_cast<std::chrono::minutes>(now-last_bmp_save).count();
+    const auto time_duration = std::chrono::duration<float>(now-last_bmp_save).count() / 60.f;
     if (time_duration < bitmap_save_time_between)
         return;
 

--- a/gst-plugin/src/drpai_controller.h
+++ b/gst-plugin/src/drpai_controller.h
@@ -67,7 +67,7 @@ private:
     /* Bitmap saving for fewer probabilities */
     std::chrono::system_clock::time_point last_bmp_save;
     float bitmap_save_class_probability = 0;
-    uint32_t bitmap_save_time_between = 5;
+    float bitmap_save_time_between = 5;
     std::string bitmap_save_directory = ".";
     std::vector<std::string> bitmap_save_classes;
     void check_save_bmp();


### PR DESCRIPTION
Kevin requested this:

> ... we want to be able to build up the dataset as fast as we can for the trucks - the time is an interesting parameter that you added to make sure we don't get flooded, but we probably want to even be able to capture multiple images of a truck going by (otherwise we'll only have images of it small and far away).

So, it was requested that the parameter be changed from an integer with a low bound of 1 minute to a float variable with a low bound of zero. This allows us to save bitmaps sooner than one minute and every frame.

It was tested in the Azure deployment.