### PR TITLE
Add support to MobileNet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Change the build to only gstreamer1.0-drpai
       run: |
-        sed -i -e 's/bitbake mistysom-image/bitbake gst-launch-split gstreamer1.0-drpai gstreamer1.0-drpai-yolo/g' rzv2l/Build/exec.sh
+        sed -i -e 's/bitbake mistysom-image/bitbake gst-launch-split gstreamer1.0-drpai gstreamer1.0-drpai-yolo gstreamer1.0-drpai-mobilenet gstreamer1.0-drpai-dummy/g' rzv2l/Build/exec.sh
         sed -i -e 's|/tmp/deploy/images/|/tmp/deploy/rpm/aarch64/*|g' rzv2l/Build/exec.sh
         sed -i '/image/d' rzv2l/Build/exec.sh
         sed -i '/rm /d' rzv2l/Build/exec.sh

--- a/.idea/deployment.xml
+++ b/.idea/deployment.xml
@@ -8,6 +8,7 @@
             <mapping deploy="/usr/lib64/libgstdrpai-yolo.so" local="$PROJECT_DIR$/buildDir/gst-plugin/src/drpai-models/drpai-yolo/libgstdrpai-yolo.so" web="/" />
             <mapping deploy="/usr/lib64/gstreamer-1.0/libgstdrpai.so" local="$PROJECT_DIR$/buildDir/gst-plugin/libgstdrpai.so" />
             <mapping deploy="/usr/lib64/libtvm_runtime.so" local="$PROJECT_DIR$/gst-plugin/src/drpai-models/drpai-tvm/rzv_drp-ai_tvm/obj/build_runtime/V2L/libtvm_runtime.so" />
+            <mapping deploy="/usr/lib64/libgstdrpai-mobilenet.so" local="$PROJECT_DIR$/buildDir/gst-plugin/src/drpai-models/drpai-mobilenet/libgstdrpai-mobilenet.so" web="" />
           </mappings>
         </serverdata>
       </paths>

--- a/bitbake-recipes/gstreamer1.0-drpai.bb
+++ b/bitbake-recipes/gstreamer1.0-drpai.bb
@@ -35,6 +35,18 @@ RDEPENDS_${PN}-yolo = "${PN}"
 FILES_${PN}-yolo = "${libdir}/libgstdrpai-yolo.so"
 FILES_${PN}-yolo-dbg = "${libdir}/.debug/libgstdrpai-yolo.so"
 
+PACKAGES += " ${PN}-dummy ${PN}-dummy-dbg"
+PROVIDES += " ${PN}-dummy"
+RDEPENDS_${PN}-dummy = "${PN}"
+FILES_${PN}-dummy = "${libdir}/libgstdrpai-dummy.so"
+FILES_${PN}-dummy-dbg = "${libdir}/.debug/libgstdrpai-dummy.so"
+
+PACKAGES += " ${PN}-mobilenet ${PN}-mobilenet-dbg"
+PROVIDES += " ${PN}-mobilenet"
+RDEPENDS_${PN}-mobilenet = "${PN}"
+FILES_${PN}-mobilenet = "${libdir}/libgstdrpai-mobilenet.so"
+FILES_${PN}-mobilenet-dbg = "${libdir}/.debug/libgstdrpai-mobilenet.so"
+
 
 PACKAGES += " gst-launch-split gst-launch-split-dbg"
 PROVIDES += " gst-launch-split"

--- a/gst-plugin/meson.build
+++ b/gst-plugin/meson.build
@@ -38,4 +38,6 @@ gstplugindrpai = library('gstdrpai',
 gstdrpai_dep = declare_dependency(link_with : gstplugindrpai, include_directories : incdir)
 
 subdir('src/drpai-models/drpai-yolo')
+subdir('src/drpai-models/drpai-dummy')
+subdir('src/drpai-models/drpai-mobilenet')
 subdir('tests')

--- a/gst-plugin/src/drpai-models/drpai-dummy/dummy_post_processor.cpp
+++ b/gst-plugin/src/drpai-models/drpai-dummy/dummy_post_processor.cpp
@@ -1,0 +1,46 @@
+//
+// Created by matin on 01/12/23.
+//
+
+#include "dummy_post_processor.h"
+#include <fstream>
+#include <mutex>
+
+void Dummy_PostProcessor::extract_detections(const std::vector<float>& inference_output_buf)
+{
+    std::unique_lock lock (mutex);
+
+    last_det.clear();
+}
+
+void Dummy_PostProcessor::open_resource(const uint32_t inference_output_size, const uint32_t img_width, uint32_t const img_height) {
+    BasePostProcessor::open_resource(inference_output_size, img_width, img_height);
+}
+
+void Dummy_PostProcessor::render_detections_on_image(Image &img) {
+    BasePostProcessor::render_detections_on_image(img);
+}
+
+std::string Dummy_PostProcessor::get_status() const {
+    return "";
+}
+
+json_array Dummy_PostProcessor::get_detections_json() {
+    return BasePostProcessor::get_detections_json();
+}
+
+json_object Dummy_PostProcessor::get_json() {
+    return BasePostProcessor::get_json();
+}
+
+bool Dummy_PostProcessor::set_property(const std::string& key, const std::string& value) {
+    return BasePostProcessor::set_property(key, value);
+}
+
+Dummy_PostProcessor::Dummy_PostProcessor(const std::string &prefix) :
+        BasePostProcessor(prefix)
+{}
+
+BasePostProcessor* create_post_processor_instance(const char* prefix) {
+    return new Dummy_PostProcessor(prefix);
+}

--- a/gst-plugin/src/drpai-models/drpai-dummy/dummy_post_processor.h
+++ b/gst-plugin/src/drpai-models/drpai-dummy/dummy_post_processor.h
@@ -1,0 +1,28 @@
+//
+// Created by matin on 01/12/23.
+//
+
+#ifndef GSTREAMER1_0_DRPAI_DUMMY_POST_PROCESSOR_H
+#define GSTREAMER1_0_DRPAI_DUMMY_POST_PROCESSOR_H
+
+#include "../base_post_processor.h"
+
+class Dummy_PostProcessor: public BasePostProcessor {
+
+public:
+    explicit Dummy_PostProcessor(const std::string& prefix);
+    ~Dummy_PostProcessor() override = default;
+
+    void open_resource(uint32_t inference_output_size, uint32_t img_width, uint32_t img_height) override;
+    void extract_detections(const std::vector<float>& inference_output_buf) override;
+    void render_detections_on_image(Image &img) override;
+    [[nodiscard]] std::string get_status() const override;
+
+    [[nodiscard]] json_array get_detections_json() override;
+    [[nodiscard]] json_object get_json() override;
+
+    [[nodiscard]] bool set_property(const std::string& key, const std::string& value) override;
+};
+
+
+#endif //GSTREAMER1_0_DRPAI_DUMMY_POST_PROCESSOR_H

--- a/gst-plugin/src/drpai-models/drpai-dummy/meson.build
+++ b/gst-plugin/src/drpai-models/drpai-dummy/meson.build
@@ -1,0 +1,10 @@
+gstdrpai_dummy_sources = [
+    'dummy_post_processor.cpp',
+]
+
+gstdrpai_dummy = library('gstdrpai-dummy',
+    gstdrpai_dummy_sources,
+    include_directories: incdir,
+    dependencies: [gstdrpai_dep],
+    install : true,
+)

--- a/gst-plugin/src/drpai-models/drpai-mobilenet/meson.build
+++ b/gst-plugin/src/drpai-models/drpai-mobilenet/meson.build
@@ -1,0 +1,10 @@
+gstdrpai_mobilenet_sources = [
+    'mobilenet_post_processor.cpp',
+]
+
+gstdrpai_mobilenet = library('gstdrpai-mobilenet',
+    gstdrpai_mobilenet_sources,
+    include_directories: incdir,
+    dependencies: [gstdrpai_dep],
+    install : true,
+)

--- a/gst-plugin/src/drpai-models/drpai-mobilenet/mobilenet_post_processor.cpp
+++ b/gst-plugin/src/drpai-models/drpai-mobilenet/mobilenet_post_processor.cpp
@@ -1,0 +1,129 @@
+//
+// Created by matin on 01/12/23.
+//
+
+#include "mobilenet_post_processor.h"
+#include <fstream>
+#include <iostream>
+#include <mutex>
+
+/*****************************************
+* Function Name : extract_detections
+* Description   : Process CPU post-processing for MobileNet (drawing bounding boxes) and print the result on console.
+* Arguments     : floatarr = float DRP-AI output data
+*                 img = image to draw the detection result
+* Return value  : 0 if succeeded
+*                 not 0 otherwise
+******************************************/
+void MobileNet_PostProcessor::extract_detections(const std::vector<float>& inference_output_buf)
+{
+    std::unique_lock lock (mutex);
+
+    const auto detection_count_max = inference_output_buf.size()/6;
+
+    const auto classes_start_index = detection_count_max*5;
+    const auto boxes_start_index = detection_count_max;
+
+    last_det.clear();
+    for (std::size_t i = 0; i< detection_count_max; i++) {
+        const auto score = inference_output_buf.at(i);
+
+        if (score > TH_PROB) {
+            const auto box_start_index = boxes_start_index + i*4;
+            const auto pred_class = static_cast<uint32_t>(inference_output_buf.at(classes_start_index + i));
+            const float y1 = inference_output_buf.at(box_start_index + 0) * static_cast<float>(img_height);
+            const float x1 = inference_output_buf.at(box_start_index + 1) * static_cast<float>(img_width);
+            const float y2 = inference_output_buf.at(box_start_index + 2) * static_cast<float>(img_height);
+            const float x2 = inference_output_buf.at(box_start_index + 3) * static_cast<float>(img_width);
+
+            const float w = x2 - x1;
+            const float h = y2 - y1;
+            const float x = (x1 + x2)/2;
+            const float y = (y1 + y2)/2;
+
+            last_det.emplace_back(
+                    Box{ x,y,w,h },
+                    pred_class, score, labels.at(pred_class).c_str()
+            );
+        }
+    }
+
+    /* Print details */
+    if(log_detects) {
+        std::cout << "DRP-AI detected items:  ";
+        for (const auto &detection: last_det) {
+            /* Print the box details on console */
+            //print_box(detection, n++);
+            std::cout << detection.to_string_hr() + "\t";
+        }
+        std::cout << std::endl;
+    }
+}
+
+void MobileNet_PostProcessor::open_resource(const uint32_t inference_output_size, const uint32_t img_width, uint32_t const img_height) {
+    BasePostProcessor::open_resource(inference_output_size, img_width, img_height);
+
+    /*Load Label from label_list file*/
+    const std::string label_list = prefix + "/" + prefix + "_labels.txt";
+    std::cout << "Loading : " << label_list << std::flush;
+    load_label_file(label_list);
+    std::cout << "\t\t\tFound classes: " << labels.size() << std::endl;
+}
+
+/*****************************************
+* Function Name     : load_label_file
+* Description       : Load label list text file and return the label list that contains the label.
+* Arguments         : label_file_name = filename of label list. must be in txt format
+* Return value      : 0 if succeeded
+*                     not 0 if error occurred
+******************************************/
+void MobileNet_PostProcessor::load_label_file(const std::string& label_file_name)
+{
+    std::ifstream infile(label_file_name);
+    if (!infile.is_open())
+        throw std::runtime_error("[ERROR] Failed to open label file: " + label_file_name);
+
+    std::string line;
+    while (getline(infile,line))
+    {
+        if (line.empty())
+            continue;
+        labels.push_back(line);
+        if (infile.fail())
+            throw std::runtime_error("[ERROR] Failed to read label file: " + label_file_name);
+    }
+    infile.close();
+}
+
+void MobileNet_PostProcessor::render_detections_on_image(Image &img) {
+    BasePostProcessor::render_detections_on_image(img);
+}
+
+std::string MobileNet_PostProcessor::get_status() const {
+    return "";
+}
+
+json_array MobileNet_PostProcessor::get_detections_json() {
+    return BasePostProcessor::get_detections_json();
+}
+
+json_object MobileNet_PostProcessor::get_json() {
+    return BasePostProcessor::get_json();
+}
+
+bool MobileNet_PostProcessor::set_property(const std::string& key, const std::string& value) {
+    if (key == "filter-prob") {
+        TH_PROB = std::stof(value) / 100.f;
+    } else {
+        return BasePostProcessor::set_property(key, value);
+    }
+    return true;
+}
+
+MobileNet_PostProcessor::MobileNet_PostProcessor(const std::string &prefix) :
+        BasePostProcessor(prefix)
+{}
+
+BasePostProcessor* create_post_processor_instance(const char* prefix) {
+    return new MobileNet_PostProcessor(prefix);
+}

--- a/gst-plugin/src/drpai-models/drpai-mobilenet/mobilenet_post_processor.h
+++ b/gst-plugin/src/drpai-models/drpai-mobilenet/mobilenet_post_processor.h
@@ -1,0 +1,34 @@
+//
+// Created by matin on 01/12/23.
+//
+
+#ifndef GSTREAMER1_0_DRPAI_MOBILENET_POST_PROCESSOR_H
+#define GSTREAMER1_0_DRPAI_MOBILENET_POST_PROCESSOR_H
+
+#include "../base_post_processor.h"
+
+class MobileNet_PostProcessor: public BasePostProcessor {
+
+public:
+    explicit MobileNet_PostProcessor(const std::string& prefix);
+    ~MobileNet_PostProcessor() override = default;
+
+    void open_resource(uint32_t inference_output_size, uint32_t img_width, uint32_t img_height) override;
+    void extract_detections(const std::vector<float>& inference_output_buf) override;
+    void render_detections_on_image(Image &img) override;
+    [[nodiscard]] std::string get_status() const override;
+
+    [[nodiscard]] json_array get_detections_json() override;
+    [[nodiscard]] json_object get_json() override;
+
+    [[nodiscard]] bool set_property(const std::string& key, const std::string& value) override;
+
+private:
+    float TH_PROB = 0.5f;
+    std::vector<std::string> labels {};
+
+    void load_label_file(const std::string& label_file_name);
+};
+
+
+#endif //GSTREAMER1_0_DRPAI_MOBILENET_POST_PROCESSOR_H

--- a/gst-plugin/src/drpai-models/drpai-tvm/tvm_drpai.cpp
+++ b/gst-plugin/src/drpai-models/drpai-tvm/tvm_drpai.cpp
@@ -37,8 +37,35 @@ void TVM_DRPAI::open_resource(const uint32_t data_in_address, const bool open_fi
     runtime.LoadModel(prefix, drpaimem_addr_start+0x38E0000);
 
     input_data_type = runtime.GetInputDataType(0);
-    const auto output = runtime.GetOutput(0);
-    const auto output_size = std::get<2>(output);
+
+    switch (input_data_type) {
+        case InOutDataType::INT64:
+            std::cerr << "Error: Input data type INT64 is not supported." << std::endl;
+            break;
+        case InOutDataType::OTHER:
+            std::cerr << "Error: Input data type is unknown and not supported." << std::endl;
+            break;
+        default:
+            break;
+    }
+
+    const auto output_num = runtime.GetNumOutput();
+    long output_size = 0;
+    for (int i=0; i<output_num; i++) {
+        const auto output = runtime.GetOutput(i);
+
+        switch (std::get<0>(output)) {
+            case InOutDataType::INT64:
+                std::cout << "Warning: Output data type INT64 is not supported for output index " << i << std::endl;
+            break;
+            case InOutDataType::OTHER:
+                std::cout << "Warning: Output data type is unknown and not supported for output index " << i << std::endl;
+            break;
+            default:
+                output_size += std::get<2>(output);
+                break;
+        }
+    }
     drpai_output_buf.resize(output_size);
 }
 
@@ -65,44 +92,63 @@ void TVM_DRPAI::run_inference() {
             runtime.SetInput(0, static_cast<uint16_t *>(preprocess_output_ptr));
             break;
         default:
-            throw std::runtime_error("[ERROR] Non-floating point output data type is not supported.");
+            break;
     }
 
     runtime.Run();
     const auto t3 = std::chrono::high_resolution_clock::now();
 
     /* Get the number of output of the target model. For ResNet, 1 output. */
-    auto output_num = runtime.GetNumOutput();
-    if (output_num != 1)
-        throw std::runtime_error("[ERROR] Output layer count " + std::to_string(output_num) + " not supported.");
+    const auto output_num = runtime.GetNumOutput();
+    int64_t output_start_index = 0;
 
-    /* Comparing output with reference.*/
-    /* output_buffer below is tuple, which is { data type, address of output data, number of elements } */
-    const auto output_buffer = runtime.GetOutput(0);
-    const int64_t out_size = std::get<2>(output_buffer);
-    /* Array to store the FP32 output data from inference. */
-    switch (std::get<0>(output_buffer)) {
-        case InOutDataType::FLOAT16: {
-            /* Extract data in FP16 <uint16_t>. */
-            const auto *data_ptr = static_cast<uint16_t *>(std::get<1>(output_buffer));
+    for (int i=0; i<output_num; i++) {
+        /* output_buffer below is tuple, which is { data type, address of output data, number of elements } */
+        const auto output_buffer = runtime.GetOutput(i);
+        const int64_t out_size = std::get<2>(output_buffer);
+        /* Array to store the FP32 output data from inference. */
+        switch (std::get<0>(output_buffer)) {
+            case InOutDataType::FLOAT16: {
+                /* Extract data in FP16 <uint16_t>. */
+                const auto *data_ptr = static_cast<uint16_t *>(std::get<1>(output_buffer));
 
-            /* Post-processing for FP16 */
-            /* Cast FP16 output data to FP32. */
-            for (int n = 0; n < out_size; n++)
-            {
-                drpai_output_buf.at(n) = float16_to_float32(data_ptr[n]);
+                /* Post-processing for FP16 */
+                /* Cast FP16 output data to FP32. */
+                for (int n = 0; n < out_size; n++)
+                {
+                    drpai_output_buf.at(n + output_start_index) = float16_to_float32(data_ptr[n]);
+                }
+                output_start_index += out_size;
+                break;
             }
-            break;
+            case InOutDataType::FLOAT32: {
+                /* Extract data in FP32 <float>. */
+                const auto *data_ptr = static_cast<float *>(std::get<1>(output_buffer));
+                /*Copy output data to buffer for post-processing. */
+                for (int n = 0; n < out_size; n++)
+                {
+                    drpai_output_buf.at(n + output_start_index) = data_ptr[n];
+                }
+                output_start_index += out_size;
+                break;
+            }
+            case InOutDataType::INT64: {
+                /* Extract data in INT64 <float>. */
+                const auto *data_ptr = static_cast<int64_t *>(std::get<1>(output_buffer));
+
+                /* Post-processing for INT64 */
+                /* Cast INT64 output data to FP32. */
+                for (int n = 0; n < out_size; n++)
+                {
+                    drpai_output_buf.at(n + output_start_index) = static_cast<float>(data_ptr[n]);
+                }
+                output_start_index += out_size;
+                break;
+            }
+            case InOutDataType::OTHER: {
+                break;
+            }
         }
-        case InOutDataType::FLOAT32: {
-            /* Extract data in FP32 <float>. */
-            const auto *data_ptr = static_cast<float *>(std::get<1>(output_buffer));
-            /*Copy output data to buffer for post-processing. */
-            drpai_output_buf.assign(data_ptr, data_ptr + out_size);
-            break;
-        }
-        default:
-            throw std::runtime_error("[ERROR] Non-floating point output data type is not supported.");
     }
     const auto t4 = std::chrono::high_resolution_clock::now();
 

--- a/gst-plugin/src/drpai_controller.cpp
+++ b/gst-plugin/src/drpai_controller.cpp
@@ -194,19 +194,20 @@ void DRPAI_Controller::thread_function_loop() {
 }
 
 void DRPAI_Controller::thread_function_single() {
-    {
-        std::unique_lock lock(state_mutex);
-        if (thread_state == Closing)
-            throw std::exception();
-
-        thread_state = Ready;
-        if (multithread) {
-            v.wait(lock, [&] { return thread_state != Ready; });
-        }
-    }
-
     try {
+        const auto t0 = std::chrono::high_resolution_clock::now();
+        {
+            std::unique_lock lock(state_mutex);
+            if (thread_state == Closing)
+                throw std::exception();
+
+            thread_state = Ready;
+            if (multithread) {
+                v.wait(lock, [&] { return thread_state != Ready; });
+            }
+        }
         const auto t1 = std::chrono::high_resolution_clock::now();
+
         image_mapped_udma->prepare();
         const auto t2 = std::chrono::high_resolution_clock::now();
 
@@ -216,18 +217,28 @@ void DRPAI_Controller::thread_function_single() {
         postprocessor->extract_detections(drpai->drpai_output_buf);
         const auto t4 = std::chrono::high_resolution_clock::now();
 
+        check_save_bmp();
+        const auto t5 = std::chrono::high_resolution_clock::now();
+
+        send_socket_data();
+        const auto t6 = std::chrono::high_resolution_clock::now();
+
         if (log_exec_time) {
+            const auto ms_int0 = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
             const auto ms_int1 = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
             const auto ms_int2 = std::chrono::duration_cast<std::chrono::milliseconds>(t3 - t2).count();
             const auto ms_int3 = std::chrono::duration_cast<std::chrono::milliseconds>(t4 - t3).count();
+            const auto ms_int4 = std::chrono::duration_cast<std::chrono::milliseconds>(t5 - t4).count();
+            const auto ms_int5 = std::chrono::duration_cast<std::chrono::milliseconds>(t6 - t5).count();
             std::cout << "Inference Time: " << drpai->get_log_exec_time() << std::endl;
-            std::cout << "Execution Time - UDMA prepare: " << ms_int1
+            std::cout << "Execution Time - Lock: "<< ms_int0
+                      << "ms\tUDMA prepare: " << ms_int1
                       << "ms\tInference: " << ms_int2
-                      << "ms\tPostProcess: " << ms_int3 << "ms" << std::endl;
+                      << "ms\tPostProcess: " << ms_int3
+                      << "ms\tSaveBMP: " << ms_int4
+                      << "ms\tSendSocket: " << ms_int5
+                      << "ms" << std::endl;
         }
-
-        check_save_bmp();
-        send_socket_data();
 
         if (error_retries > 0) {
             std::cout << "DRPAI recovered after retrying." << std::endl;


### PR DESCRIPTION
In this pull request, I added post-processing support for the model MobileNetV2.

I also added a dummy post-processing that allows us to benchmark a model's runtime without having any post-processing or detection output.

The bounding boxes were matched with input frames to confirm the correct detection format.