### PR TITLE
Improve anchors file reading

### DIFF
--- a/gst-plugin/src/drpai-models/drpai-yolo/yolo_post_processor.cpp
+++ b/gst-plugin/src/drpai-models/drpai-yolo/yolo_post_processor.cpp
@@ -277,15 +277,12 @@ void YOLO_PostProcessor::load_anchors_file(const std::string &anchors_file_name)
     if (!infile.is_open()) {
         throw std::runtime_error("[ERROR] Failed to open anchors file: " + anchors_file_name);
     }
-    std::string line;
-    while (getline(infile, line)) {
-        if (line.empty()) {
-            continue;
-        }
-        anchors.push_back(std::stof(line));
-        if (infile.fail()) {
-            throw std::runtime_error("[ERROR] Failed to read anchors file: " + anchors_file_name);
-        }
+    float f = 0;
+    while (infile >> f) {
+        anchors.push_back(f);
+    }
+    if (!infile.eof()) {
+        throw std::runtime_error("[ERROR] Failed to read anchors file: " + anchors_file_name);
     }
     infile.close();
 }


### PR DESCRIPTION
This PR updates the anchors file reading method to directly read floating-point values, simplifying the parsing logic and improving efficiency. Additionally, it catches errors during file reading more robustly.

Most importantly, the anchors file can optionally now look like below, which is more readable. But there still should not be any other characters other than space, tab `\t`, return `\r`, and line break `\n`.
```
10      13
16      30
33      23
30      61
62      45
59      119
116     90
156     198
373     326
```

Lastly, this would potentially help #65 in implementing a prior read method