### PR TITLE
Remove gstreamer1.0-plugins-base from dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get update && \
     git \
     g++ \    
     libgstreamer1.0-dev \
-    libgstreamer-plugins-base1.0-dev \
     net-tools \
     ninja-build \
     openssh-client \

--- a/bitbake-recipes/gstreamer1.0-drpai.bb
+++ b/bitbake-recipes/gstreamer1.0-drpai.bb
@@ -14,14 +14,13 @@ PACKAGES = "${PN} ${PN}-dbg"
 
 MESONOPTS += " -Dtvm=enabled"
 DEPENDS = "\
-    gstreamer1.0-plugins-base \
+    gstreamer1.0 \
     drpai \
     mmngr-user-module \
     mmngrbuf-user-module \
 "
 RDEPENDS_${PN} = "\
   gstreamer1.0 \
-  gstreamer1.0-plugins-base \
   mmngr-user-module \
   mmngrbuf-user-module \
   libtvm_runtime \

--- a/gst-plugin/src/drpai-models/drpai-dummy/dummy_post_processor.cpp
+++ b/gst-plugin/src/drpai-models/drpai-dummy/dummy_post_processor.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "dummy_post_processor.h"
-#include <fstream>
 
 void Dummy_PostProcessor::extract_detections(const std::vector<float> &inference_output_buf) { detections.clear(); }
 

--- a/gst-plugin/src/drpai-models/drpai-mobilenet/mobilenet_post_processor.cpp
+++ b/gst-plugin/src/drpai-models/drpai-mobilenet/mobilenet_post_processor.cpp
@@ -3,8 +3,6 @@
 //
 
 #include "mobilenet_post_processor.h"
-#include <fstream>
-#include <iostream>
 
 /*****************************************
  * Function Name : extract_detections

--- a/meson.build
+++ b/meson.build
@@ -20,11 +20,6 @@ gst_dep = dependency(
   required: true,
   fallback: ['gstreamer', 'gst_dep'],
 )
-gstbase_dep = dependency(
-  'gstreamer-base-1.0',
-  version: '>=1.16.3',
-  fallback: ['gstreamer', 'gst_base_dep'],
-)
 thread_dep = dependency('threads')
 dl_dep = cxx.find_library('dl', required: true)
 


### PR DESCRIPTION
Refactors dependencies for the GStreamer plugin, removing the direct dependency on `gstreamer1.0-plugins-base`.

This streamlines the build process and reduces potential conflicts by relying on the core `gstreamer1.0` package which transitively provides the necessary base functionalities.