### PR TITLE
Refactor DRP-AI output buffer handling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -109,6 +109,17 @@
         "streambuf": "cpp",
         "thread": "cpp",
         "cinttypes": "cpp",
-        "typeinfo": "cpp"
+        "typeinfo": "cpp",
+        "bitset": "cpp",
+        "complex": "cpp",
+        "csignal": "cpp",
+        "list": "cpp",
+        "set": "cpp",
+        "unordered_set": "cpp",
+        "regex": "cpp",
+        "future": "cpp",
+        "iomanip": "cpp",
+        "shared_mutex": "cpp",
+        "variant": "cpp"
     },
 }

--- a/gst-plugin/src/drivers/drpai-tvm/drpai_tvm.cpp
+++ b/gst-plugin/src/drivers/drpai-tvm/drpai_tvm.cpp
@@ -51,8 +51,9 @@ void DRPAI_TVM::open_resource(const bool open_files)
             break;
     }
 
-    const auto output_num  = runtime.GetNumOutput();
-    long       output_size = 0;
+    const auto output_num = runtime.GetNumOutput();
+    drpai_output_buf.resize(output_num);
+
     for (int i = 0; i < output_num; i++) {
         const auto output = runtime.GetOutput(i);
 
@@ -65,11 +66,11 @@ void DRPAI_TVM::open_resource(const bool open_files)
                           << std::endl;
                 break;
             default:
-                output_size += std::get<2>(output);
+                long output_size = std::get<2>(output);
+                drpai_output_buf.at(i).resize(output_size);
                 break;
         }
     }
-    drpai_output_buf.resize(output_size);
 }
 
 void DRPAI_TVM::set_data_in_address(uint32_t data_in_address) { in_param.pre_in_addr = data_in_address; }
@@ -106,8 +107,7 @@ void DRPAI_TVM::run_inference()
     const auto t3 = std::chrono::high_resolution_clock::now();
 
     /* Get the number of output of the target model. For ResNet, 1 output. */
-    const auto output_num         = runtime.GetNumOutput();
-    int64_t    output_start_index = 0;
+    const auto output_num = runtime.GetNumOutput();
 
     for (int i = 0; i < output_num; i++) {
         /* output_buffer below is tuple, which is { data type, address of output data, number of elements } */
@@ -122,9 +122,8 @@ void DRPAI_TVM::run_inference()
                 /* Post-processing for FP16 */
                 /* Cast FP16 output data to FP32. */
                 for (int n = 0; n < out_size; n++) {
-                    drpai_output_buf.at(n + output_start_index) = float16_to_float32(data_ptr[n]);
+                    drpai_output_buf.at(i).at(n) = float16_to_float32(data_ptr[n]);
                 }
-                output_start_index += out_size;
                 break;
             }
             case InOutDataType::FLOAT32: {
@@ -132,9 +131,8 @@ void DRPAI_TVM::run_inference()
                 const auto *data_ptr = static_cast<float *>(std::get<1>(output_buffer));
                 /*Copy output data to buffer for post-processing. */
                 for (int n = 0; n < out_size; n++) {
-                    drpai_output_buf.at(n + output_start_index) = data_ptr[n];
+                    drpai_output_buf.at(i).at(n) = data_ptr[n];
                 }
-                output_start_index += out_size;
                 break;
             }
             case InOutDataType::INT64: {
@@ -144,9 +142,8 @@ void DRPAI_TVM::run_inference()
                 /* Post-processing for INT64 */
                 /* Cast INT64 output data to FP32. */
                 for (int n = 0; n < out_size; n++) {
-                    drpai_output_buf.at(n + output_start_index) = static_cast<float>(data_ptr[n]);
+                    drpai_output_buf.at(i).at(n) = static_cast<float>(data_ptr[n]);
                 }
-                output_start_index += out_size;
                 break;
             }
             case InOutDataType::OTHER: {

--- a/gst-plugin/src/drivers/drpai-tvm/drpai_tvm.h
+++ b/gst-plugin/src/drivers/drpai-tvm/drpai_tvm.h
@@ -29,8 +29,8 @@ private:
     MeraDrpRuntimeWrapper runtime;
     /* Pre-processing Runtime Object */
     PreRuntime        preruntime;
-    InOutDataType     input_data_type;
-    s_preproc_param_t in_param = {};
+    InOutDataType     input_data_type = InOutDataType::OTHER;
+    s_preproc_param_t in_param        = {};
 
     uint64_t ms_int1 = 0, ms_int2 = 0, ms_int3 = 0;
 };

--- a/gst-plugin/src/drivers/drpai_native.cpp
+++ b/gst-plugin/src/drivers/drpai_native.cpp
@@ -129,7 +129,7 @@ void DRPAI_Native::get_result()
                                  std::string(std::strerror(errno)));
     }
     /* Read the memory via DRP-AI Driver and store the output to buffer */
-    if (read(drpai_fd, drpai_output_buf.data(), drpai_data.size) == -1) {
+    if (read(drpai_fd, drpai_output_buf.at(0).data(), drpai_data.size) == -1) {
         throw std::runtime_error("[ERROR] Failed to read via DRP-AI Driver:  errno=" + std::to_string(errno) + " " +
                                  std::string(std::strerror(errno)));
     }
@@ -218,7 +218,8 @@ void DRPAI_Native::open_resource(const bool open_files)
 
     const std::string drpai_address_file = directory + "/" + prefix + "_addrmap_intm.txt";
     read_addrmap_txt(drpai_address_file);
-    drpai_output_buf.resize(proc.at(DRPAI_INDEX_OUTPUT).size / sizeof(float));
+    drpai_output_buf.resize(1);
+    drpai_output_buf.at(0).resize(proc.at(DRPAI_INDEX_OUTPUT).size / sizeof(float));
 
     /*Load pixel format from data_in_list file*/
     const static std::string data_in_list = directory + "/" + prefix + "_data_in_list.txt";

--- a/gst-plugin/src/drivers/drpai_native.h
+++ b/gst-plugin/src/drivers/drpai_native.h
@@ -79,8 +79,9 @@ public:
     int32_t      IN_CHANNEL = 0;
     IMAGE_FORMAT IN_FORMAT  = BGR_DATA;
 
-    /// The float array which needs to be post-processed to extract meaningful information
-    std::vector<float> drpai_output_buf;
+    /// The float arrays which needs to be post-processed to extract meaningful information
+    /// Some models output multiple arrays
+    std::vector<std::vector<float>> drpai_output_buf;
 
 protected:
     const std::string prefix;    /// The prefix of the DRP-AI object files.

--- a/gst-plugin/src/drpai-models/base_post_processor.cpp
+++ b/gst-plugin/src/drpai-models/base_post_processor.cpp
@@ -53,10 +53,10 @@ BasePostProcessor::BasePostProcessor(const std::string &prefix) :
 
 /// Opens post processor resources.
 /// This function can get overridden by the child class to allocate any additional devices, libraries, files, etc.
-/// @param [in] inference_output_size The size of output layer
+/// @param [in] inference_output_size The size of output buffers
 /// @param [in] img_width The width of the input image to match bounding box locations.
 /// @param [in] img_height The height of the input image to match bounding box locations.
-void BasePostProcessor::open_resource(uint32_t inference_output_size, const uint32_t img_width,
+void BasePostProcessor::open_resource(const std::vector<uint32_t> &inference_output_size, const uint32_t img_width,
                                       const uint32_t img_height, const uint32_t num_classes)
 {
     BasePostProcessor::img_width   = img_width;

--- a/gst-plugin/src/drpai-models/base_post_processor.h
+++ b/gst-plugin/src/drpai-models/base_post_processor.h
@@ -18,14 +18,14 @@ public:
 
     /// Opens post processor resources.
     /// This function can get overridden by the child class to allocate any additional devices, libraries, files, etc.
-    /// @param [in] inference_output_size The size of output layer
+    /// @param [in] inference_output_size The size of output buffers
     /// @param [in] img_width The width of the input image to match bounding box locations.
     /// @param [in] img_height The height of the input image to match bounding box locations.
     /// @param [in] num_classes The number of classes with labels
-    virtual void open_resource(uint32_t inference_output_size, uint32_t img_width, uint32_t img_height,
-                               uint32_t num_classes);
+    virtual void open_resource(const std::vector<uint32_t> &inference_output_size, uint32_t img_width,
+                               uint32_t img_height, uint32_t num_classes);
 
-    virtual void print_string_hr(const std::vector<std::string> &labels) const;
+    virtual void print_string_hr(std::vector<std::string> const &labels) const;
 
     /// Get status to be shown at the corner of the image.
     /// This function usually gets overridden by the child class. But it is not a must.
@@ -54,7 +54,7 @@ public:
     /// Extract information from the output layer of the running ML model and writes them into the last detections list.
     /// This function MUST be implemented by the child class
     /// @param [in] inference_output_buf Array of floats containing the output layer of the running ML model.
-    virtual void extract_detections(const std::vector<float> &inference_output_buf) = 0;
+    virtual void extract_detections(const std::vector<std::vector<float>> &inference_output_buf) = 0;
 
 protected:
     /// Loads post process params list text file and finds the param variable.

--- a/gst-plugin/src/drpai-models/drpai-dummy/dummy_post_processor.cpp
+++ b/gst-plugin/src/drpai-models/drpai-dummy/dummy_post_processor.cpp
@@ -4,14 +4,17 @@
 
 #include "dummy_post_processor.h"
 
-void Dummy_PostProcessor::extract_detections(const std::vector<float> &inference_output_buf) { detections.clear(); }
+void Dummy_PostProcessor::extract_detections(std::vector<std::vector<float>> const &inference_output_buf)
+{
+    detections.clear();
+}
 
 void Dummy_PostProcessor::print_string_hr(const std::vector<std::string> &labels) const
 {
     BasePostProcessor::print_string_hr(labels);
 }
 
-void Dummy_PostProcessor::open_resource(const uint32_t inference_output_size, const uint32_t img_width,
+void Dummy_PostProcessor::open_resource(const std::vector<uint32_t> &inference_output_size, const uint32_t img_width,
                                         uint32_t const img_height, const uint32_t num_classes)
 {
     BasePostProcessor::open_resource(inference_output_size, img_width, img_height, num_classes);

--- a/gst-plugin/src/drpai-models/drpai-dummy/dummy_post_processor.h
+++ b/gst-plugin/src/drpai-models/drpai-dummy/dummy_post_processor.h
@@ -13,12 +13,12 @@ public:
     explicit Dummy_PostProcessor(const std::string &prefix);
     ~Dummy_PostProcessor() override = default;
 
-    void open_resource(uint32_t inference_output_size, uint32_t img_width, uint32_t img_height,
+    void open_resource(const std::vector<uint32_t> &inference_output_size, uint32_t img_width, uint32_t img_height,
                        uint32_t num_classes) override;
-    void extract_detections(const std::vector<float> &inference_output_buf) override;
-    void print_string_hr(const std::vector<std::string> &labels) const override;
+    void extract_detections(std::vector<std::vector<float>> const &inference_output_buf) override;
+    void print_string_hr(std::vector<std::string> const &labels) const override;
 
     [[nodiscard]] std::string get_status() const override;
-    [[nodiscard]] json_array  get_detections_json(const std::vector<std::string> &labels) const override;
-    [[nodiscard]] json_object get_json(const std::vector<std::string> &labels) const override;
+    [[nodiscard]] json_array  get_detections_json(std::vector<std::string> const &labels) const override;
+    [[nodiscard]] json_object get_json(std::vector<std::string> const &labels) const override;
 };

--- a/gst-plugin/src/drpai-models/drpai-mobilenet/mobilenet_post_processor.cpp
+++ b/gst-plugin/src/drpai-models/drpai-mobilenet/mobilenet_post_processor.cpp
@@ -3,9 +3,9 @@
 //
 
 #include "mobilenet_post_processor.h"
+#include <array>
 #include <fstream>
 #include <iostream>
-#include <vector>
 
 /*****************************************
  * Function Name : extract_detections

--- a/gst-plugin/src/drpai-models/drpai-mobilenet/mobilenet_post_processor.cpp
+++ b/gst-plugin/src/drpai-models/drpai-mobilenet/mobilenet_post_processor.cpp
@@ -3,6 +3,8 @@
 //
 
 #include "mobilenet_post_processor.h"
+#include <fstream>
+#include <iostream>
 
 /*****************************************
  * Function Name : extract_detections
@@ -12,24 +14,27 @@
  * Return value  : 0 if succeeded
  *                 not 0 otherwise
  ******************************************/
-void MobileNet_PostProcessor::extract_detections(const std::vector<float> &inference_output_buf)
+void MobileNet_PostProcessor::extract_detections(const std::vector<std::vector<float>> &inference_output_buf)
 {
-    const auto detection_count_max = inference_output_buf.size() / 6;
-
-    const auto classes_start_index = detection_count_max * 5;
-    const auto boxes_start_index   = detection_count_max;
+    if (output_index_boxes == -1) {
+        // If output indices are not set, update them. It only needs to be done on the first output.
+        update_output_indices(inference_output_buf);
+    }
+    const auto &scores_buffer  = inference_output_buf.at(output_index_scores);
+    const auto &boxes_buffer   = inference_output_buf.at(output_index_boxes);
+    const auto &classes_buffer = inference_output_buf.at(output_index_classes);
 
     detections.clear();
-    for (std::size_t i = 0; i < detection_count_max; i++) {
-        const auto score = inference_output_buf.at(i);
+    for (std::size_t i = 0; i < scores_buffer.size(); i++) {
+        const auto score = scores_buffer.at(i);
 
         if (score > TH_PROB) {
-            const auto  box_start_index = boxes_start_index + (i * 4);
-            const auto  pred_class      = static_cast<uint32_t>(inference_output_buf.at(classes_start_index + i));
-            const float y1              = inference_output_buf.at(box_start_index + 0) * static_cast<float>(img_height);
-            const float x1              = inference_output_buf.at(box_start_index + 1) * static_cast<float>(img_width);
-            const float y2              = inference_output_buf.at(box_start_index + 2) * static_cast<float>(img_height);
-            const float x2              = inference_output_buf.at(box_start_index + 3) * static_cast<float>(img_width);
+            const auto  pred_class = static_cast<uint32_t>(classes_buffer.at(i));
+            const auto  box_index  = i * 4;
+            const float y1         = boxes_buffer.at(box_index + 0) * static_cast<float>(img_height);
+            const float x1         = boxes_buffer.at(box_index + 1) * static_cast<float>(img_width);
+            const float y2         = boxes_buffer.at(box_index + 2) * static_cast<float>(img_height);
+            const float x2         = boxes_buffer.at(box_index + 3) * static_cast<float>(img_width);
 
             const float w = x2 - x1;
             const float h = y2 - y1;
@@ -39,6 +44,45 @@ void MobileNet_PostProcessor::extract_detections(const std::vector<float> &infer
             detections.emplace_back(Box{x, y, w, h}, pred_class, score);
         }
     }
+}
+
+void MobileNet_PostProcessor::update_output_indices(std::vector<std::vector<float>> const &inference_output_buf)
+{
+    // Define all possible combinations of output indices
+    constexpr uint32_t combination_count = 4 * 3 * 2 * 1;
+
+    constexpr std::array<std::array<int, 3>, combination_count> combinations = {{
+            {0, 1, 2}, {0, 1, 3}, {0, 2, 1}, {0, 2, 3}, {0, 3, 1}, {0, 3, 2}, {1, 0, 2}, {1, 0, 3},
+            {1, 2, 0}, {1, 2, 3}, {1, 3, 0}, {1, 3, 2}, {2, 0, 1}, {2, 0, 3}, {2, 1, 0}, {2, 1, 3},
+            {2, 3, 0}, {2, 3, 1}, {3, 0, 1}, {3, 0, 2}, {3, 1, 0}, {3, 1, 2}, {3, 2, 0}, {3, 2, 1},
+    }};
+
+    if (inference_output_buf.size() != 4) {
+        throw std::runtime_error("MobileNet: Inference output buffer count mismatch. Expected 4, got " +
+                                 std::to_string(inference_output_buf.size()));
+    }
+
+    for (const auto &indices: combinations) {
+        const auto *scores_buffer  = &inference_output_buf.at(indices.at(0));
+        const auto *boxes_buffer   = &inference_output_buf.at(indices.at(1));
+        const auto *classes_buffer = &inference_output_buf.at(indices.at(2));
+        if (boxes_buffer->size() % 4 == 0 &&                            // Boxes have 4 floats
+            boxes_buffer->size() / 4 == scores_buffer->size() &&        // Each box has a score
+            scores_buffer->size() == classes_buffer->size() &&          // Each score has a class
+            std::floor(scores_buffer->at(0)) != scores_buffer->at(0) && // Score is not an integer
+            std::floor(classes_buffer->at(0)) == classes_buffer->at(0)  // Class is an integer
+        ) {
+
+            std::cout << "MobileNet: Output indices matched successfully." << std::endl;
+            output_index_scores  = indices.at(0);
+            output_index_boxes   = indices.at(1);
+            output_index_classes = indices.at(2);
+            return;
+        }
+    }
+
+    // If no valid combination was found, throw an error
+    throw std::runtime_error("Inference output buffer sizes mismatch.");
 }
 
 MobileNet_PostProcessor::MobileNet_PostProcessor(const std::string &prefix) : BasePostProcessor(prefix) {}

--- a/gst-plugin/src/drpai-models/drpai-mobilenet/mobilenet_post_processor.cpp
+++ b/gst-plugin/src/drpai-models/drpai-mobilenet/mobilenet_post_processor.cpp
@@ -5,6 +5,7 @@
 #include "mobilenet_post_processor.h"
 #include <fstream>
 #include <iostream>
+#include <vector>
 
 /*****************************************
  * Function Name : extract_detections

--- a/gst-plugin/src/drpai-models/drpai-mobilenet/mobilenet_post_processor.h
+++ b/gst-plugin/src/drpai-models/drpai-mobilenet/mobilenet_post_processor.h
@@ -13,5 +13,12 @@ public:
     explicit MobileNet_PostProcessor(const std::string &prefix);
     ~MobileNet_PostProcessor() override = default;
 
-    void extract_detections(const std::vector<float> &inference_output_buf) override;
+    void extract_detections(std::vector<std::vector<float>> const &inference_output_buf) override;
+
+private:
+    int output_index_classes = -1;
+    int output_index_boxes   = -1;
+    int output_index_scores  = -1;
+
+    void update_output_indices(std::vector<std::vector<float>> const &inference_output_buf);
 };

--- a/gst-plugin/src/drpai-models/drpai-yolo/yolo_post_processor.cpp
+++ b/gst-plugin/src/drpai-models/drpai-yolo/yolo_post_processor.cpp
@@ -50,20 +50,20 @@ void YOLO_PostProcessor::softmax(std::vector<float> &val)
 }
 
 struct matrix_ref {
-    const std::vector<float> &t;
+    const std::vector<float> *t;
     uint32_t                  x_len;
     uint32_t                  y_len;
 
-    explicit matrix_ref(const std::vector<float> &t, uint32_t x_len, uint32_t y_len) : t(t), x_len(x_len), y_len(y_len)
+    explicit matrix_ref(const std::vector<float> *t, uint32_t x_len, uint32_t y_len) : t(t), x_len(x_len), y_len(y_len)
     {
-        if (t.size() != static_cast<long>(x_len) * y_len) {
+        if (t->size() != static_cast<long>(x_len) * y_len) {
             throw std::runtime_error(
-                    "[Error] The source vector size does not match the matrix sizes: " + std::to_string(t.size()) +
+                    "[Error] The source vector size does not match the matrix sizes: " + std::to_string(t->size()) +
                     " != " + std::to_string(x_len) + "x" + std::to_string(y_len));
         }
     }
 
-    [[nodiscard]] const float &get(const uint32_t x, const uint32_t y) const { return t.at((y * x_len) + x); }
+    [[nodiscard]] const float &get(const uint32_t x, const uint32_t y) const { return t->at((y * x_len) + x); }
 };
 
 /*****************************************
@@ -74,8 +74,11 @@ struct matrix_ref {
  * Return value  : 0 if succeeded
  *                 not 0 otherwise
  ******************************************/
-void YOLO_PostProcessor::extract_detections(const std::vector<float> &inference_output_buf)
+void YOLO_PostProcessor::extract_detections(const std::vector<std::vector<float>> &inference_output_buf)
 {
+    // YOLO only has one output
+    const auto &output = inference_output_buf.at(0);
+
     std::vector<float> classes(num_classes);
     detections.clear();
 
@@ -83,7 +86,7 @@ void YOLO_PostProcessor::extract_detections(const std::vector<float> &inference_
         case 'x':
         case 'X':
         case '8': {
-            const matrix_ref m(inference_output_buf, sum_grids, item_size);
+            const matrix_ref m(&output, sum_grids, item_size);
             for (uint32_t item = 0; item < sum_grids; item++) {
                 for (uint32_t i = 0; i < classes.size(); i++) {
                     classes.at(i) = m.get(item, 4 + i);
@@ -112,7 +115,7 @@ void YOLO_PostProcessor::extract_detections(const std::vector<float> &inference_
                         for (uint32_t x = 0; x < num_grid; x++) {
                             const uint32_t offs = yolo_offset(n, b, y, x);
 
-                            const float &tc = inference_output_buf.at(yolo_index(num_grid, offs, 4));
+                            const float &tc = output.at(yolo_index(num_grid, offs, 4));
 
                             auto objectness = sigmoid(tc);
                             if (objectness < TH_PROB) {
@@ -120,7 +123,7 @@ void YOLO_PostProcessor::extract_detections(const std::vector<float> &inference_
                             }
                             /* Get the class prediction */
                             for (uint32_t i = 0; i < classes.size(); i++) {
-                                classes.at(i) = inference_output_buf.at(yolo_index(num_grid, offs, 5 + i));
+                                classes.at(i) = output.at(yolo_index(num_grid, offs, 5 + i));
                             }
 
                             switch (yolo_version) {
@@ -141,10 +144,10 @@ void YOLO_PostProcessor::extract_detections(const std::vector<float> &inference_
                             /* Store the result into the list if the probability is more than the threshold */
                             if (probability >= TH_PROB) {
                                 const uint32_t pred_class = max_pred - classes.begin();
-                                const float   &tx         = inference_output_buf.at(yolo_index(num_grid, offs, 0));
-                                const float   &ty         = inference_output_buf.at(yolo_index(num_grid, offs, 1));
-                                const float   &tw         = inference_output_buf.at(yolo_index(num_grid, offs, 2));
-                                const float   &th         = inference_output_buf.at(yolo_index(num_grid, offs, 3));
+                                const float   &tx         = output.at(yolo_index(num_grid, offs, 0));
+                                const float   &ty         = output.at(yolo_index(num_grid, offs, 1));
+                                const float   &tw         = output.at(yolo_index(num_grid, offs, 2));
+                                const float   &th         = output.at(yolo_index(num_grid, offs, 3));
 
                                 /* Compute the bounding box */
                                 /*get_yolo_box/get_region_box in paper implementation*/
@@ -196,7 +199,7 @@ void YOLO_PostProcessor::extract_detections(const std::vector<float> &inference_
     }
 }
 
-void YOLO_PostProcessor::open_resource(const uint32_t inference_output_size, const uint32_t img_width,
+void YOLO_PostProcessor::open_resource(const std::vector<uint32_t> &inference_output_size, const uint32_t img_width,
                                        const uint32_t img_height, uint32_t num_classes)
 {
     BasePostProcessor::open_resource(inference_output_size, img_width, img_height, num_classes);
@@ -245,7 +248,7 @@ void YOLO_PostProcessor::open_resource(const uint32_t inference_output_size, con
                 sum_grids += n * n;
             }
 
-            num_bb = inference_output_size / (item_size * sum_grids);
+            num_bb = inference_output_size.at(0) / (item_size * sum_grids);
             std::cout << " & num BB: " << num_bb << std::endl;
             if (num_bb == 0) {
                 throw std::runtime_error("[ERROR] Either classes or grids are not matching with the model output.");
@@ -256,7 +259,7 @@ void YOLO_PostProcessor::open_resource(const uint32_t inference_output_size, con
         case 'X':
         case '8':
             item_size = num_classes + 4;
-            sum_grids = inference_output_size / item_size;
+            sum_grids = inference_output_size.at(0) / item_size;
             num_bb    = 1;
             break;
         default:

--- a/gst-plugin/src/drpai-models/drpai-yolo/yolo_post_processor.h
+++ b/gst-plugin/src/drpai-models/drpai-yolo/yolo_post_processor.h
@@ -13,9 +13,9 @@ public:
     explicit YOLO_PostProcessor(const std::string &prefix);
     ~YOLO_PostProcessor() override = default;
 
-    void open_resource(uint32_t inference_output_size, uint32_t img_width, uint32_t img_height,
+    void open_resource(const std::vector<uint32_t> &inference_output_size, uint32_t img_width, uint32_t img_height,
                        uint32_t num_classes) override;
-    void extract_detections(const std::vector<float> &inference_output_buf) override;
+    void extract_detections(std::vector<std::vector<float>> const &inference_output_buf) override;
 
 private:
     float    MODEL_IN_W   = 0;
@@ -31,14 +31,17 @@ private:
     void load_anchors_file(const std::string &anchors_file_name);
     void load_num_grids(const std::string &data_out_list_file_name);
 
-    [[nodiscard]] uint32_t                  yolo_offset(uint8_t n, uint32_t b, uint32_t y, uint32_t x) const;
+    [[nodiscard]] uint32_t yolo_offset(uint8_t n, uint32_t b, uint32_t y, uint32_t x) const;
+
     [[nodiscard]] constexpr static uint32_t yolo_index(const uint8_t num_grid, const uint32_t offs,
                                                        const uint32_t channel)
     {
         return offs + (channel * num_grid * num_grid);
     }
+
     [[nodiscard]] constexpr static float sigmoid(const float x) { return 1.0F / (1.0F + std::exp(-x)); }
-    static void                          sigmoid(std::vector<float> &val)
+
+    static void sigmoid(std::vector<float> &val)
     {
         for (auto &v: val) {
             v = sigmoid(v);

--- a/gst-plugin/src/drpai_controller.cpp
+++ b/gst-plugin/src/drpai_controller.cpp
@@ -172,7 +172,11 @@ void DRPAI_Controller::open_resources_with_image_size(uint16_t image_width, uint
     image_mapped_udma->map_dma_buffer();
     drpai->set_data_in_address(image_mapped_udma->get_dma_buffer_physical_address());
 
-    postprocessor->open_resource(drpai->drpai_output_buf.size(), image_width, image_height, labels.size());
+    std::vector<uint32_t> inference_output_size;
+    for (const auto &buf: drpai->drpai_output_buf) {
+        inference_output_size.push_back(buf.size());
+    }
+    postprocessor->open_resource(inference_output_size, image_width, image_height, labels.size());
 
     if (det_filterer.is_filter_region_active())
         std::cout << "Option : Filtering region of interest to " << det_filterer.get_filter_region_json().to_string()

--- a/gst-plugin/src/utils/json.h
+++ b/gst-plugin/src/utils/json.h
@@ -57,7 +57,7 @@ protected:
                 add(static_cast<int>(value));
                 return;
             default: {
-                std::ostringstream out;
+                std::ostringstream out{};
                 out << std::fixed << std::setprecision(precision) << value;
                 s += out.str();
             }

--- a/gst-plugin/src/utils/rate_sleeper.h
+++ b/gst-plugin/src/utils/rate_sleeper.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <thread>
+#include "consts.h"
 
 /**
  * @brief Utility class to maintain a maximum execution rate by sleeping as needed.
@@ -16,7 +17,7 @@ private:
     float last_sleep_duration = 0; /**< Duration of the last sleep in seconds. */
 
 public:
-    float max = 1.0F / 120; /**< Maximum allowed duration per cycle in seconds. */
+    float max = 1.0F / FRAMERATE_MAX; /**< Maximum allowed duration per cycle in seconds. */
 
     /**
      * @brief Default constructor for rate_sleeper.

--- a/scripts/remote_launch.sh
+++ b/scripts/remote_launch.sh
@@ -9,7 +9,8 @@ SSH_CMD="sshpass -e ssh \
   -o ControlMaster=auto \
   -o ControlPath=${SOCK} \
   -o ControlPersist=180 \
-  -o StrictHostKeyChecking=no ${MISTYSOM_USER}@${MISTYSOM_HOST}"
+  -o StrictHostKeyChecking=no \
+  ${MISTYSOM_USER}@${MISTYSOM_HOST}"
 
 cleanup() {
   ./scripts/remote_stop.sh


### PR DESCRIPTION
Changes the DRP-AI drivers to manage multiple output buffers. This allows the system to handle models with multiple output layers more efficiently. Updates post-processing to correctly access the new buffer structure.

The previous implementation assumed a single output buffer, which is not always the case. This commit modifies the system to support multiple output buffers and ensures correct data handling.